### PR TITLE
feat: /deathset als Officer-Kommando via Addon-Whisper

### DIFF
--- a/Death.lua
+++ b/Death.lua
@@ -237,20 +237,28 @@ end
 -- Define slash command
 SLASH_DEATHSET1 = '/deathset'
 SlashCmdList["DEATHSET"] = function(msg)
-	local inputValue = tonumber(msg)
+	if not CanGuildInvite() then
+		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Keine Berechtigung für diesen Befehl.|r")
+		return
+	end
 
-	-- If user didn't provide a number, show error message with instructions
+	local targetName, valueStr = msg:match("^(%S+)%s+(%S+)$")
+	if not targetName or not valueStr then
+		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Verwendung: /deathset <Spielername> <Zahl>|r")
+		return
+	end
+
+	local inputValue = tonumber(valueStr)
 	if not inputValue then
-		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Invalid input. Use: /deathset <number>|r")
+		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Ungültige Zahl: " .. valueStr .. "|r")
 		return
 	end
 
-	-- Validation: Number must be in a reasonable range
 	if inputValue < 0 or inputValue > 999999 then
-		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Value must be between 0 and 999999|r")
+		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Wert muss zwischen 0 und 999999 liegen.|r")
 		return
 	end
 
-	CharacterDeaths = inputValue
-	SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS .. "Death counter set to " .. CharacterDeaths .. "|r")
+	C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "DEATHSET|" .. tostring(inputValue), "WHISPER", targetName)
+	SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS .. "Deathset-Nachricht an " .. targetName .. " gesendet.|r")
 end

--- a/Global.lua
+++ b/Global.lua
@@ -205,6 +205,15 @@ function SchlingelInc.Global:Initialize()
 
                     HandleDeathAddonMessage(message, sender)
 
+                    if message:match("^DEATHSET|") and SchlingelInc:IsValidGuildSender(sender) then
+                        local valueStr = message:match("^DEATHSET|(.+)$")
+                        local value = tonumber(valueStr)
+                        if value and value >= 0 and value <= 999999 then
+                            CharacterDeaths = value
+                            SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS .. "Deathcounter auf " .. CharacterDeaths .. " gesetzt.|r")
+                        end
+                    end
+
 					SchlingelInc.GuildProfiles:HandleMessage(sender, message)
 				end
 			end


### PR DESCRIPTION
## Summary

- `/deathset` erfordert jetzt `CanGuildInvite()`-Berechtigung
- Neue Syntax: `/deathset <Spielername> <Zahl>`
- Officer sendet `DEATHSET|<value>` per Addon-Whisper an den Zielspieler
- Spieler-Client empfängt die Nachricht und setzt `CharacterDeaths` automatisch

Closes #107