### PR TITLE
fix: CanGuildRemove durch CanGuildInvite ersetzen

### DIFF
--- a/Global.lua
+++ b/Global.lua
@@ -345,7 +345,7 @@ end
 -- Encodes and writes guild rules into the SchlingelInc block of guild info text.
 -- Returns true on success, false if the player lacks officer permission.
 function SchlingelInc:WriteGuildInfo(mail, ah, trade, group, blockedTrader, cap)
-    if not CanGuildRemove() then return false end
+    if not CanGuildInvite() then return false end
     local mailRule = tonumber(mail)
     if mailRule ~= 0 and mailRule ~= 1 and mailRule ~= 2 then
         mailRule = mail and 1 or 0

--- a/LevelUp.lua
+++ b/LevelUp.lua
@@ -4,7 +4,7 @@ SchlingelInc.LevelUps.progressCache = {}  -- shortName -> { level, xpCurrent, xp
 
 -- Persists an entry to the officer-only progress DB.
 local function SaveProgressEntry(shortName, entry)
-    if not CanGuildRemove() then return end
+    if not CanGuildInvite() then return end
     SchlingelProgressDB = SchlingelProgressDB or {}
     SchlingelProgressDB[shortName] = entry
 end
@@ -97,7 +97,7 @@ function SchlingelInc.LevelUps:Initialize()
         function()
             -- Officers: restore progress cache from persistent storage.
             C_Timer.After(2, function()
-                if CanGuildRemove() and SchlingelProgressDB then
+                if CanGuildInvite() and SchlingelProgressDB then
                     for k, v in pairs(SchlingelProgressDB) do
                         if not SchlingelInc.LevelUps.progressCache[k] then
                             SchlingelInc.LevelUps.progressCache[k] = v
@@ -181,7 +181,7 @@ function SchlingelInc.LevelUps:Initialize()
         end, 0, "LevelUpProgressReceive")
 
     local function PruneProgressCache()
-        if not CanGuildRemove() then return end
+        if not CanGuildInvite() then return end
         local members = {}
         local total = GetNumGuildMembers() or 0
         for i = 1, total do

--- a/MiniMapIcon.lua
+++ b/MiniMapIcon.lua
@@ -27,7 +27,7 @@ if LDB then -- Only proceeds if LibDataBroker is available
                     end
                 end
             elseif button == "RightButton" then
-                if IsInGuild() and CanGuildRemove() then
+                if IsInGuild() and CanGuildInvite() then
                     SchlingelInc.OfficerPanel:Toggle()
                 end
             end
@@ -41,7 +41,7 @@ if LDB then -- Only proceeds if LibDataBroker is available
             if IsInGuild() then
                 GameTooltip:AddLine("Linksklick: Gilde anzeigen", 1, 1, 1)
                 GameTooltip:AddLine("Shift+Linksklick: Tode anzeigen", 0.8, 0.8, 0.8)
-                if CanGuildRemove() then
+                if CanGuildInvite() then
                     GameTooltip:AddLine("Rechtsklick: Offizier Panel", 0.8, 0.8, 0.8)
                 end
             else

--- a/interfaces/InactivityWindow.lua
+++ b/interfaces/InactivityWindow.lua
@@ -194,14 +194,14 @@ function SchlingelInc:CreateInactivityWindow()
 				durationText:SetText(member.displayDuration)
 
 				-- Kick button (if player has permission)
-				if CanGuildRemove() then
+				if CanGuildInvite() then
 					local kickBtn = CreateFrame("Button", nil, rowFrame, "UIPanelButtonTemplate")
 					kickBtn:SetSize(80, rowHeight - 2)
 					kickBtn:SetPoint("TOPLEFT", rowFrame, "TOPLEFT", 430, 0)
 					kickBtn:SetText("Entfernen")
 					kickBtn:SetScript("OnClick", function()
 						-- Recheck permission at click time in case it changed
-						if not CanGuildRemove() then
+						if not CanGuildInvite() then
 							SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR ..
 								"Du hast keine Berechtigung mehr, Spieler zu entfernen.|r")
 							return

--- a/interfaces/OfficerPanel/Frame.lua
+++ b/interfaces/OfficerPanel/Frame.lua
@@ -189,7 +189,7 @@ end
 -- ── Public API ────────────────────────────────────────────────────────────────
 
 function SchlingelInc.OfficerPanel:Toggle()
-    if not CanGuildRemove() then return end
+    if not CanGuildInvite() then return end
     if not OfficerPanel.frame then
         OfficerPanel.frame = BuildPanel()
     end
@@ -201,7 +201,7 @@ function SchlingelInc.OfficerPanel:Toggle()
 end
 
 function SchlingelInc.OfficerPanel:ShowInvites()
-    if not CanGuildRemove() then return end
+    if not CanGuildInvite() then return end
     if not OfficerPanel.frame then OfficerPanel.frame = BuildPanel() end
     if not OfficerPanel.frame:IsShown() then OfficerPanel.frame:Show() end
     OfficerPanel.frame.SwitchToInvites()

--- a/interfaces/OfficerPanel/TabInactive.lua
+++ b/interfaces/OfficerPanel/TabInactive.lua
@@ -146,7 +146,7 @@ function OfficerPanel.BuildInactiveTab(ic)
                 kickBtn:SetText("Entfernen")
                 local fullName = member.fullName
                 kickBtn:SetScript("OnClick", function()
-                    if not CanGuildRemove() then return end
+                    if not CanGuildInvite() then return end
                     StaticPopup_Show("CONFIRM_GUILD_KICK", fullName, nil, { memberName = fullName })
                 end)
             end

--- a/interfaces/OfficerPanel/init.lua
+++ b/interfaces/OfficerPanel/init.lua
@@ -21,5 +21,5 @@ OfficerPanel.progressFilter = {
 OfficerPanel.discordFilter  = { filterName = "", minCount = nil }
 
 function OfficerPanel.IsOfficer()
-    return CanGuildRemove()
+    return CanGuildInvite()
 end


### PR DESCRIPTION
## Summary

- Alle `CanGuildRemove()`-Aufrufe durch `CanGuildInvite()` ersetzt
- Betrifft: `Global.lua`, `LevelUp.lua`, `MiniMapIcon.lua`, `InactivityWindow.lua`, `OfficerPanel/Frame.lua`, `OfficerPanel/TabInactive.lua`
- Officers in niedrigeren Rängen (z. B. Großschlingel) haben damit Zugriff auf das Officer Panel und alle weiteren officer-gesicherten Funktionen

Closes #108