### PR TITLE
feat: Progress Tab Lag-Spikes beheben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.1.0
+
+- Großschlingel haben jetzt Zugriff auf das Offizier-Panel
+- `/deathset` ist jetzt ein Officer-Kommando und wird per Addon-Whisper an den Zielspieler übermittelt
+
 # 4.0.9
 
 - Noch mehr Offis hinzugefügt um der Flut an Invite Requests gerecht zu werden.

--- a/LevelUp.lua
+++ b/LevelUp.lua
@@ -86,6 +86,39 @@ local function CheckForMilestone(level)
 end
 
 function SchlingelInc.LevelUps:Initialize()
+    local progressLoadTotal    = 0
+    local progressLoadReceived = 0
+    local progressLoadTimer    = nil
+
+    local function EndProgressLoad()
+        if progressLoadTimer then progressLoadTimer:Cancel() progressLoadTimer = nil end
+        progressLoadTotal    = 0
+        progressLoadReceived = 0
+        if OfficerPanel and OfficerPanel.EndProgressLoad then OfficerPanel.EndProgressLoad() end
+        SchlingelInc.OfficerPanel:RefreshProgress()
+    end
+
+    SchlingelInc.LevelUps.StartLoad = function(total)
+        progressLoadTotal    = total
+        progressLoadReceived = 0
+        if progressLoadTimer then progressLoadTimer:Cancel() end
+        progressLoadTimer = C_Timer.NewTimer(math.max(5, total * 0.5 + 5), EndProgressLoad)
+        local panel = SchlingelInc.OfficerPanel
+        if panel and panel.StartProgressLoad then panel.StartProgressLoad(total) end
+    end
+
+    SchlingelInc.LevelUps.OnProgressReceived = function()
+        if progressLoadTotal == 0 then return end
+        progressLoadReceived = progressLoadReceived + 1
+        local panel = SchlingelInc.OfficerPanel
+        if panel and panel.UpdateProgressLoad then
+            panel.UpdateProgressLoad(progressLoadReceived, progressLoadTotal)
+        end
+        if progressLoadReceived >= progressLoadTotal then
+            EndProgressLoad()
+        end
+    end
+
     SchlingelInc.EventManager:RegisterHandler("PLAYER_LEVEL_UP",
         function(_, level)
             CheckForMilestone(level)
@@ -176,7 +209,7 @@ function SchlingelInc.LevelUps:Initialize()
                 }
                 SchlingelInc.LevelUps.progressCache[shortName] = entry
                 SaveProgressEntry(shortName, entry)
-                SchlingelInc.OfficerPanel:RefreshProgress()
+                SchlingelInc.LevelUps.OnProgressReceived()
             end
         end, 0, "LevelUpProgressReceive")
 
@@ -202,12 +235,35 @@ function SchlingelInc.LevelUps:Initialize()
         function() PruneProgressCache() CacheOwnProgress() end, 0, "LevelUpProgressPrune")
 end
 
-function SchlingelInc.LevelUps:RequestProgress()
+function SchlingelInc.LevelUps:RequestProgress(targetName)
     if not IsInGuild() then return end
 
     CacheOwnProgress()
-    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "PROGRESS_REQUEST", "GUILD")
-    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "VERSION_REQUEST", "GUILD")
+
+    if targetName then
+        SchlingelInc.LevelUps.StartLoad(1)
+        C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "PROGRESS_REQUEST", "WHISPER", targetName)
+        return
+    end
+
+    -- Staggered whispers to avoid simultaneous response flood
+    local online = {}
+    local selfName = UnitName("player")
+    for i = 1, GetNumGuildMembers() or 0 do
+        local name, _, _, _, _, _, _, _, isOnline = GetGuildRosterInfo(i)
+        if name and isOnline then
+            local short = SchlingelInc:RemoveRealmFromName(name)
+            if short ~= selfName then
+                table.insert(online, short)
+            end
+        end
+    end
+    SchlingelInc.LevelUps.StartLoad(#online)
+    for i, name in ipairs(online) do
+        C_Timer.After((i - 1) * 0.5, function()
+            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "PROGRESS_REQUEST", "WHISPER", name)
+        end)
+    end
 end
 
 function SchlingelInc.LevelUps:CheckForCap(level, announce)

--- a/SchlingelInc.toc
+++ b/SchlingelInc.toc
@@ -2,7 +2,7 @@
 ## Title: Schlingel Inc
 ## Notes: Visit DerHauges Discord for more information: https://discord.gg/KXkyUZW
 ## Author: Cricksu, Pudi, Canasterzaster
-## Version: 4.0.9
+## Version: 4.1.0
 ## IconTexture: Interface\AddOns\SchlingelInc\media\graphics\SI_Transp_512_x_512_px.tga
 ## SavedVariablesPerCharacter: CharacterDeaths, SchlingelOptionsDB, SchlingelOwnProfile
 ## SavedVariables: DiscordHandle, Pronouns, SchlingelGuildProfileCache, SchlingelGuildDB, SchlingelProgressDB

--- a/interfaces/OfficerPanel/TabProgress.lua
+++ b/interfaces/OfficerPanel/TabProgress.lua
@@ -68,6 +68,7 @@ function OfficerPanel.BuildProgressTab(pc)
         end)
     end
 
+    -- Right side: Offline toggle + member count
     local pCountFs = pc:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     pCountFs:SetPoint("RIGHT", pc, "TOPRIGHT", -4, -11)
     pCountFs:SetJustifyH("RIGHT")
@@ -99,20 +100,48 @@ function OfficerPanel.BuildProgressTab(pc)
     pOfflineBtn:SetScript("OnEnter", function() pOfflineLbl:SetTextColor(1, 1, 0.7, 1) end)
     pOfflineBtn:SetScript("OnLeave", UpdateOfflineBtn)
 
+    -- Left side: Lade-Indikator | Anfordern | Versionen | Filter
+    local pLoadFs = pc:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    pLoadFs:SetPoint("LEFT", pc, "TOPLEFT", 4, -11)
+    pLoadFs:SetWidth(72)
+    pLoadFs:SetJustifyH("LEFT")
+    pLoadFs:SetTextColor(0.6, 0.82, 1, 1)
+    pLoadFs:Hide()
+
     local pRequestBtn = CreateFrame("Button", nil, pc, "UIPanelButtonTemplate")
-    pRequestBtn:SetSize(96, 18)
-    pRequestBtn:SetPoint("RIGHT", pOfflineBtn, "LEFT", -6, 0)
+    pRequestBtn:SetSize(90, 18)
+    pRequestBtn:SetPoint("TOPLEFT", pc, "TOPLEFT", 80, -4)
     pRequestBtn:SetText("Anfordern")
     pRequestBtn:SetScript("OnClick", function()
         SchlingelInc.LevelUps:RequestProgress()
-        if OfficerPanel.frame and OfficerPanel.frame:IsShown() then
-            OfficerPanel.RefreshProgress()
+    end)
+
+    local pVersionBtn = CreateFrame("Button", nil, pc, "UIPanelButtonTemplate")
+    pVersionBtn:SetSize(80, 18)
+    pVersionBtn:SetPoint("LEFT", pRequestBtn, "RIGHT", 4, 0)
+    pVersionBtn:SetText("Versionen")
+    pVersionBtn:SetScript("OnClick", function()
+        if IsInGuild() then
+            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "VERSION_REQUEST", "GUILD")
         end
     end)
 
+    OfficerPanel.StartProgressLoad = function(total)
+        pLoadFs:SetText("Lade 0/" .. total)
+        pLoadFs:Show()
+    end
+
+    OfficerPanel.UpdateProgressLoad = function(received, total)
+        pLoadFs:SetText("Lade " .. received .. "/" .. total)
+    end
+
+    OfficerPanel.EndProgressLoad = function()
+        pLoadFs:Hide()
+    end
+
     local pfFilterBtn = CreateFrame("Button", nil, pc, "UIPanelButtonTemplate")
-    pfFilterBtn:SetSize(70, 18)
-    pfFilterBtn:SetPoint("RIGHT", pRequestBtn, "LEFT", -6, 0)
+    pfFilterBtn:SetSize(60, 18)
+    pfFilterBtn:SetPoint("LEFT", pVersionBtn, "RIGHT", 4, 0)
     pfFilterBtn:SetText("Filter")
     pfFilterBtn:SetScript("OnClick", function()
         local fp = OfficerPanel.tabFilterPanels.progress
@@ -155,6 +184,7 @@ function OfficerPanel.BuildProgressTab(pc)
     end
 
     local function RefreshProgress()
+        if not pc:IsShown() then return end
         for _, row in ipairs(pc.progressRows) do row:Hide() end
         wipe(pc.progressRows)
 
@@ -326,6 +356,12 @@ function OfficerPanel.BuildProgressTab(pc)
             local row = CreateFrame("Frame", nil, pScrollChild)
             row:SetSize(SCROLL_W, ROW_H)
             row:SetPoint("TOPLEFT", 0, -(idx - 1) * ROW_H)
+            row:EnableMouse(true)
+            row:SetScript("OnMouseUp", function(_, btn)
+                if btn == "LeftButton" then
+                    SchlingelInc.LevelUps:RequestProgress(entry.name)
+                end
+            end)
 
             local atCap = cap > 0 and entry.level >= cap
             if atCap and entry.xpStop == false then
@@ -337,6 +373,12 @@ function OfficerPanel.BuildProgressTab(pc)
                 bg:SetAllPoints()
                 bg:SetColorTexture(1, 1, 1, 0.03)
             end
+
+            local hoverTex = row:CreateTexture(nil, "BACKGROUND")
+            hoverTex:SetAllPoints()
+            hoverTex:SetColorTexture(1, 1, 1, 0)
+            row:SetScript("OnEnter", function() hoverTex:SetColorTexture(1, 1, 1, 0.06) end)
+            row:SetScript("OnLeave", function() hoverTex:SetColorTexture(1, 1, 1, 0) end)
 
             local nameFs = row:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
             nameFs:SetPoint("LEFT", row, "LEFT", 4, 0)


### PR DESCRIPTION
## Summary

- Guild-Broadcast `PROGRESS_REQUEST` durch gestaffelte Whispers ersetzt (0,5 s Abstand)
- Klick auf eine Zeile sendet gezielten Request an genau diesen Spieler
- Lade-Indikator zeigt Fortschritt; UI wird erst nach Abschluss aller Antworten einmalig neu aufgebaut
- `VERSION_REQUEST` aus dem Anfordern-Button ausgelagert in eigenen „Versionen"-Button
- Neue Spalte „Version" zeigt installierte Addon-Version pro Spieler 
- Version bump 4.1.0

Closes #106