### PR TITLE
feat: hover tooltip im Progress Tab

### DIFF
--- a/SchlingelInc.toc
+++ b/SchlingelInc.toc
@@ -41,6 +41,7 @@ interfaces\DiscordHandlePrompt.lua
 interfaces\GuildJoinPrompt.lua
 interfaces\SetupWizard.lua
 interfaces\FilterPanel.lua
+interfaces\MemberInspector.lua
 interfaces\OfficerPanel\init.lua
 interfaces\OfficerPanel\Frame.lua
 interfaces\OfficerPanel\TabRules.lua

--- a/interfaces/GuildPanel/Data.lua
+++ b/interfaces/GuildPanel/Data.lua
@@ -3,28 +3,11 @@
 -- Reads sort/filter state from SchlingelInc.GuildPanel (set in init.lua).
 
 local GP = SchlingelInc.GuildPanel
-
--- Returns the translated profession name only (no rank suffix) — used for filter matching.
-local function ProfName(profile, slot)
-    if not profile then return nil end
-    local name = profile["prof" .. slot]
-    if not name then return nil end
-    return SchlingelInc.Constants.PROFESSION_NAMES_DE[name] or name
-end
-
-local function ProfString(profile, slot)
-    if not profile then return nil end
-    local name = profile["prof" .. slot]
-    if not name then return nil end
-    name = SchlingelInc.Constants.PROFESSION_NAMES_DE[name] or name
-    local rank = profile["prof" .. slot .. "rank"]
-    return rank and (name .. " (" .. rank .. ")") or name
-end
+local MI = SchlingelInc.MemberInspector
 
 function GP.BuildRosterData()
     local data    = {}
     local n       = GetNumGuildMembers()
-    local ownName = UnitName("player")
 
     for i = 1, n do
         -- Field order (TBC Classic):
@@ -34,32 +17,7 @@ function GP.BuildRosterData()
             GetGuildRosterInfo(i)
         if fullName then
             local shortName = SchlingelInc:RemoveRealmFromName(fullName)
-            local isOwn     = shortName == ownName
-
-            -- For own character use the per-character SavedVars directly — they are
-            -- always current and don't depend on the broadcast having been received yet.
-            -- For other players fall back to the guild profile cache.
-            local role, prof1, prof2, profName1, profName2, discord, deaths
-
-            if isOwn then
-                local p = SchlingelOwnProfile or {}
-                role      = p.role or ""
-                prof1     = ProfString(p, 1)
-                prof2     = ProfString(p, 2)
-                profName1 = ProfName(p, 1)
-                profName2 = ProfName(p, 2)
-                discord   = DiscordHandle or ""
-                deaths    = CharacterDeaths or 0
-            else
-                local profile = SchlingelGuildProfileCache and SchlingelGuildProfileCache[shortName]
-                role      = profile and profile.role    or ""
-                prof1     = ProfString(profile, 1)
-                prof2     = ProfString(profile, 2)
-                profName1 = ProfName(profile, 1)
-                profName2 = ProfName(profile, 2)
-                discord   = profile and profile.discord or ""
-                deaths    = profile and profile.deaths  -- nil = no profile received yet
-            end
+            local mi        = MI.GetProfileEntry(shortName)
 
             table.insert(data, {
                 name         = shortName,
@@ -71,13 +29,13 @@ function GP.BuildRosterData()
                 zone         = zone         or "",
                 note         = note         or "",
                 online       = isOnline == true,  -- normalise: GetGuildRosterInfo may return nil
-                role         = role,
-                prof1        = prof1,
-                prof2        = prof2,
-                profName1    = profName1,
-                profName2    = profName2,
-                discord      = discord,
-                deaths       = deaths,  -- nil | number  (nil = no profile data yet)
+                role         = mi.role,
+                prof1        = mi.prof1,
+                prof2        = mi.prof2,
+                profName1    = mi.profName1,
+                profName2    = mi.profName2,
+                discord      = mi.discord,
+                deaths       = mi.deaths,  -- nil | number  (nil = no profile data yet)
             })
         end
     end

--- a/interfaces/GuildPanel/Frame.lua
+++ b/interfaces/GuildPanel/Frame.lua
@@ -283,7 +283,7 @@ function SchlingelInc.GuildPanel:Refresh()
 
             row:SetScript("OnEnter", function()
                 row.hl:Show()
-                GP.ShowMemberTooltip(row, entry)
+                SchlingelInc.MemberInspector.ShowTooltip(row, entry)
             end)
             row:SetScript("OnLeave", function()
                 row.hl:Hide()

--- a/interfaces/GuildPanel/Rows.lua
+++ b/interfaces/GuildPanel/Rows.lua
@@ -1,66 +1,7 @@
 -- GuildPanel/Rows.lua
--- Row frame factory, tooltip display, and class color helper.
+-- Row frame factory.
 
 local GP = SchlingelInc.GuildPanel
-
-local function ClassColor(token)
-    local c = RAID_CLASS_COLORS and token and RAID_CLASS_COLORS[token]
-    if c then return c.r, c.g, c.b end
-    return 1, 1, 1
-end
-
-function GP.ShowMemberTooltip(anchor, entry)
-    local r, g, b = ClassColor(entry.classToken)
-    GameTooltip:SetOwner(anchor, "ANCHOR_LEFT", -10, -50)
-    GameTooltip:ClearLines()
-
-    -- Name colored by class
-    GameTooltip:AddLine(entry.name, r, g, b)
-    GameTooltip:AddDoubleLine("Klasse:",
-        entry.classDisplay ~= "" and entry.classDisplay or "-",
-        0.65, 0.65, 0.65, r, g, b)
-    GameTooltip:AddDoubleLine("Rang:",
-        entry.rank ~= "" and entry.rank or "-",
-        0.65, 0.65, 0.65, 1, 1, 1)
-    if entry.zone ~= "" then
-        GameTooltip:AddDoubleLine("Zone:",
-            SchlingelInc:SanitizeText(entry.zone),
-            0.65, 0.65, 0.65, 1, 1, 1)
-    end
-
-    -- Guild note
-    local safeNote = entry.note ~= "" and SchlingelInc:SanitizeText(entry.note) or nil
-    if safeNote and safeNote ~= "" then
-        GameTooltip:AddLine(" ")
-        GameTooltip:AddDoubleLine("Notiz:", safeNote, 0.65, 0.65, 0.65, 1, 0.9, 0.5, true)
-    end
-
-    -- Profile extras
-    local hasProfile = entry.role ~= "" or entry.discord ~= "" or entry.prof1 or entry.prof2
-    if hasProfile then
-        GameTooltip:AddLine(" ")
-        if entry.role ~= "" then
-            GameTooltip:AddDoubleLine("Rolle:",   entry.role,    0.65, 0.65, 0.65, 1,    1,    1)
-        end
-        if entry.discord ~= "" then
-            GameTooltip:AddDoubleLine("Discord:", entry.discord, 0.65, 0.65, 0.65, 0.55, 0.55, 0.9)
-        end
-        if entry.prof1 then
-            GameTooltip:AddDoubleLine("Beruf 1:", entry.prof1, 0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
-        end
-        if entry.prof2 then
-            GameTooltip:AddDoubleLine("Beruf 2:", entry.prof2, 0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
-        end
-    end
-
-    -- Deaths: shown whenever we have data (including 0)
-    if entry.deaths ~= nil then
-        GameTooltip:AddLine(" ")
-        GameTooltip:AddDoubleLine("Tode:", tostring(entry.deaths), 0.65, 0.65, 0.65, 1, 1, 1)
-    end
-
-    GameTooltip:Show()
-end
 
 function GP.CreateRow(parent, index)
     local row = CreateFrame("Frame", nil, parent)

--- a/interfaces/MemberInspector.lua
+++ b/interfaces/MemberInspector.lua
@@ -1,0 +1,97 @@
+SchlingelInc.MemberInspector = {}
+local MI = SchlingelInc.MemberInspector
+
+local function ProfName(profile, slot)
+    if not profile then return nil end
+    local name = profile["prof" .. slot]
+    if not name then return nil end
+    return SchlingelInc.Constants.PROFESSION_NAMES_DE[name] or name
+end
+
+local function ProfString(profile, slot)
+    if not profile then return nil end
+    local name = profile["prof" .. slot]
+    if not name then return nil end
+    name = SchlingelInc.Constants.PROFESSION_NAMES_DE[name] or name
+    local rank = profile["prof" .. slot .. "rank"]
+    return rank and (name .. " (" .. rank .. ")") or name
+end
+
+function MI.GetProfileEntry(shortName)
+    local ownName = UnitName("player")
+    if shortName == ownName then
+        local p = SchlingelOwnProfile or {}
+        return {
+            role      = p.role or "",
+            prof1     = ProfString(p, 1),
+            prof2     = ProfString(p, 2),
+            profName1 = ProfName(p, 1),
+            profName2 = ProfName(p, 2),
+            discord   = DiscordHandle or "",
+            deaths    = CharacterDeaths or 0,
+        }
+    else
+        local profile = SchlingelGuildProfileCache and SchlingelGuildProfileCache[shortName]
+        return {
+            role      = profile and profile.role    or "",
+            prof1     = ProfString(profile, 1),
+            prof2     = ProfString(profile, 2),
+            profName1 = ProfName(profile, 1),
+            profName2 = ProfName(profile, 2),
+            discord   = profile and profile.discord or "",
+            deaths    = profile and profile.deaths,
+        }
+    end
+end
+
+function MI.ShowTooltip(anchor, entry)
+    local r, g, b = 1, 1, 1
+    local c = RAID_CLASS_COLORS and entry.classToken and RAID_CLASS_COLORS[entry.classToken]
+    if c then r, g, b = c.r, c.g, c.b end
+
+    GameTooltip:SetOwner(anchor, "ANCHOR_LEFT", -10, -50)
+    GameTooltip:ClearLines()
+
+    GameTooltip:AddLine(entry.name, r, g, b)
+    GameTooltip:AddDoubleLine("Klasse:",
+        entry.classDisplay ~= "" and entry.classDisplay or "-",
+        0.65, 0.65, 0.65, r, g, b)
+    GameTooltip:AddDoubleLine("Rang:",
+        entry.rank ~= "" and entry.rank or "-",
+        0.65, 0.65, 0.65, 1, 1, 1)
+    if entry.zone ~= "" then
+        GameTooltip:AddDoubleLine("Zone:",
+            SchlingelInc:SanitizeText(entry.zone),
+            0.65, 0.65, 0.65, 1, 1, 1)
+    end
+
+    local safeNote = entry.note ~= "" and SchlingelInc:SanitizeText(entry.note) or nil
+    if safeNote and safeNote ~= "" then
+        GameTooltip:AddLine(" ")
+        GameTooltip:AddDoubleLine("Notiz:", safeNote, 0.65, 0.65, 0.65, 1, 0.9, 0.5, true)
+    end
+
+    local hasProfile = entry.role ~= "" or entry.discord ~= "" or entry.prof1 or entry.prof2
+    if hasProfile then
+        GameTooltip:AddLine(" ")
+        if entry.role ~= "" then
+            GameTooltip:AddDoubleLine("Rolle:",   entry.role,    0.65, 0.65, 0.65, 1,    1,    1)
+        end
+        if entry.discord ~= "" then
+            GameTooltip:AddDoubleLine("Discord:", entry.discord, 0.65, 0.65, 0.65, 0.55, 0.55, 0.9)
+        end
+        if entry.prof1 then
+            GameTooltip:AddDoubleLine("Beruf 1:", entry.prof1, 0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
+        end
+        if entry.prof2 then
+            GameTooltip:AddDoubleLine("Beruf 2:", entry.prof2, 0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
+        end
+    end
+
+    if entry.deaths ~= nil then
+        GameTooltip:AddLine(" ")
+        GameTooltip:AddDoubleLine("Tode:", tostring(entry.deaths), 0.65, 0.65, 0.65, 1, 1, 1)
+    end
+
+    GameTooltip:Show()
+end

--- a/interfaces/OfficerPanel/TabProgress.lua
+++ b/interfaces/OfficerPanel/TabProgress.lua
@@ -1,4 +1,5 @@
 local OfficerPanel = SchlingelInc.OfficerPanel
+local MI = SchlingelInc.MemberInspector
 
 local function FormatGoldShort(copper)
     if not copper then return "\226\128\148" end
@@ -190,7 +191,7 @@ function OfficerPanel.BuildProgressTab(pc)
 
         local list = {}
         for i = 1, GetNumGuildMembers() or 0 do
-            local name, _, _, rosterLevel, _, _, _, _, isOnline = GetGuildRosterInfo(i)
+            local name, rankName, _, rosterLevel, classDisplay, zone, note, _, isOnline, _, classToken = GetGuildRosterInfo(i)
             if name then
                 local shortName   = SchlingelInc:RemoveRealmFromName(name)
                 local data        = SchlingelInc.LevelUps.progressCache[shortName]
@@ -215,19 +216,31 @@ function OfficerPanel.BuildProgressTab(pc)
                     timestamp  = data.timestamp or 0
                 end
 
+                local mi = MI.GetProfileEntry(shortName)
+
                 table.insert(list, {
-                    name        = shortName,
-                    level       = level,
-                    xpCurrent   = xpCurrent,
-                    xpMax       = xpMax,
-                    xpPct       = xpPct,
-                    gold        = gold,
-                    runesKnown  = runesKnown,
-                    xpStop      = xpStop,
-                    isOnline    = isOnline == true,
-                    timestamp   = timestamp,
-                    hasProgress = hasProgress,
-                    version     = GetMemberVersion(shortName),
+                    name         = shortName,
+                    level        = level,
+                    xpCurrent    = xpCurrent,
+                    xpMax        = xpMax,
+                    xpPct        = xpPct,
+                    gold         = gold,
+                    runesKnown   = runesKnown,
+                    xpStop       = xpStop,
+                    isOnline     = isOnline == true,
+                    timestamp    = timestamp,
+                    hasProgress  = hasProgress,
+                    version      = GetMemberVersion(shortName),
+                    rank         = rankName     or "",
+                    classDisplay = classDisplay or "",
+                    classToken   = classToken   or "",
+                    zone         = zone         or "",
+                    note         = note         or "",
+                    role         = mi.role,
+                    prof1        = mi.prof1,
+                    prof2        = mi.prof2,
+                    discord      = mi.discord,
+                    deaths       = mi.deaths,
                 })
             end
         end
@@ -377,8 +390,14 @@ function OfficerPanel.BuildProgressTab(pc)
             local hoverTex = row:CreateTexture(nil, "BACKGROUND")
             hoverTex:SetAllPoints()
             hoverTex:SetColorTexture(1, 1, 1, 0)
-            row:SetScript("OnEnter", function() hoverTex:SetColorTexture(1, 1, 1, 0.06) end)
-            row:SetScript("OnLeave", function() hoverTex:SetColorTexture(1, 1, 1, 0) end)
+            row:SetScript("OnEnter", function()
+                hoverTex:SetColorTexture(1, 1, 1, 0.06)
+                MI.ShowTooltip(row, entry)
+            end)
+            row:SetScript("OnLeave", function()
+                hoverTex:SetColorTexture(1, 1, 1, 0)
+                GameTooltip:Hide()
+            end)
 
             local nameFs = row:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
             nameFs:SetPoint("LEFT", row, "LEFT", 4, 0)


### PR DESCRIPTION
## Summary

- Hover-Tooltip aus dem GuildPanel ist jetzt auch im Progress Tab sichtbar
- Tooltip-Logik und Profil-Lookup in neues Modul `interfaces/MemberInspector.lua` ausgelagert
- Duplikate (`ProfString`, `ProfName`, inline Profil-Lookup) aus `GuildPanel/Data.lua`, `GuildPanel/Rows.lua` und `OfficerPanel/TabProgress.lua` entfernt

## Test plan

- [x] Progress Tab öffnen und über einen Spieler hovern → Tooltip mit Name, Klasse, Rang, Zone, Notiz, Rolle, Discord, Berufen und Toden erscheint
- [x] GuildPanel Tooltip funktioniert weiterhin wie gewohnt
- [ ] Eigener Charakter zeigt aktuelle Daten aus SavedVars