### PR TITLE
fix: präferierte Pronomen werden im Tooltip angezeigt

### DIFF
--- a/GuildProfiles.lua
+++ b/GuildProfiles.lua
@@ -13,7 +13,7 @@ SchlingelOwnProfile        = SchlingelOwnProfile        or {}
 local MSG_PROFILE = "PROFILE2"
 
 -- Serialise own profile into a single addon message string.
--- Format: PROFILE2|role|prof1name|prof1rank|prof2name|prof2rank|discord|deaths
+-- Format: PROFILE2|role|prof1name|prof1rank|prof2name|prof2rank|discord|deaths|pronouns
 local function Serialize()
     local p      = SchlingelOwnProfile
     local handle = DiscordHandle or ""
@@ -27,6 +27,7 @@ local function Serialize()
         p.prof2rank and tostring(p.prof2rank) or "",
         handle,
         deaths,
+        Pronouns or "",
     }, "|")
 end
 
@@ -43,6 +44,7 @@ local function Deserialize(payload)
         prof2rank = parts[5] ~= "" and tonumber(parts[5]) or nil,
         discord   = parts[6] ~= "" and parts[6] or nil,
         deaths    = parts[7] ~= "" and tonumber(parts[7]) or nil,
+        pronouns  = parts[8] and parts[8] ~= "" and parts[8] or nil,
         lastSeen  = time(),
     }
 end

--- a/interfaces/DiscordHandlePrompt.lua
+++ b/interfaces/DiscordHandlePrompt.lua
@@ -18,6 +18,7 @@ end
 function SchlingelInc:SetPreferredPronouns(pronouns)
     Pronouns = pronouns
     SchlingelInc:ClearGuildNote()
+    SchlingelInc.GuildProfiles:Broadcast()
 end
 
 -- Returns handle with pronouns appended if present: "myhandle (he/him)" or "myhandle"

--- a/interfaces/MemberInspector.lua
+++ b/interfaces/MemberInspector.lua
@@ -29,17 +29,19 @@ function MI.GetProfileEntry(shortName)
             profName2 = ProfName(p, 2),
             discord   = DiscordHandle or "",
             deaths    = CharacterDeaths or 0,
+            pronouns  = Pronouns or "",
         }
     else
         local profile = SchlingelGuildProfileCache and SchlingelGuildProfileCache[shortName]
         return {
-            role      = profile and profile.role    or "",
+            role      = profile and profile.role     or "",
             prof1     = ProfString(profile, 1),
             prof2     = ProfString(profile, 2),
             profName1 = ProfName(profile, 1),
             profName2 = ProfName(profile, 2),
-            discord   = profile and profile.discord or "",
+            discord   = profile and profile.discord  or "",
             deaths    = profile and profile.deaths,
+            pronouns  = profile and profile.pronouns or "",
         }
     end
 end
@@ -71,20 +73,23 @@ function MI.ShowTooltip(anchor, entry)
         GameTooltip:AddDoubleLine("Notiz:", safeNote, 0.65, 0.65, 0.65, 1, 0.9, 0.5, true)
     end
 
-    local hasProfile = entry.role ~= "" or entry.discord ~= "" or entry.prof1 or entry.prof2
+    local hasProfile = entry.role ~= "" or entry.pronouns ~= "" or entry.discord ~= "" or entry.prof1 or entry.prof2
     if hasProfile then
         GameTooltip:AddLine(" ")
         if entry.role ~= "" then
-            GameTooltip:AddDoubleLine("Rolle:",   entry.role,    0.65, 0.65, 0.65, 1,    1,    1)
+            GameTooltip:AddDoubleLine("Rolle:",    entry.role,    0.65, 0.65, 0.65, 1,    1,    1)
+        end
+        if entry.pronouns ~= "" then
+            GameTooltip:AddDoubleLine("Pronomen:", entry.pronouns, 0.65, 0.65, 0.65, 1,   1,    1)
         end
         if entry.discord ~= "" then
-            GameTooltip:AddDoubleLine("Discord:", entry.discord, 0.65, 0.65, 0.65, 0.55, 0.55, 0.9)
+            GameTooltip:AddDoubleLine("Discord:",  entry.discord, 0.65, 0.65, 0.65, 0.55, 0.55, 0.9)
         end
         if entry.prof1 then
-            GameTooltip:AddDoubleLine("Beruf 1:", entry.prof1, 0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
+            GameTooltip:AddDoubleLine("Beruf 1:",  entry.prof1,   0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
         end
         if entry.prof2 then
-            GameTooltip:AddDoubleLine("Beruf 2:", entry.prof2, 0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
+            GameTooltip:AddDoubleLine("Beruf 2:",  entry.prof2,   0.65, 0.65, 0.65, 0.9, 0.75, 0.4)
         end
     end
 


### PR DESCRIPTION
Closes #116

## Summary

- `Pronouns` wird jetzt im PROFILE2-Broadcast mitgesendet und bei anderen Spielern deserialisiert
- `SetPreferredPronouns` triggert einen Broadcast, damit Änderungen sofort verteilt werden
- Pronomen erscheinen als eigene Zeile im Hover-Tooltip (GuildPanel + Progress Tab)