### PR TITLE
ChatThrottleLib für AddonMessages nutzen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Neuer "Schande"-Tab im Gildenpanel: zeigt die eigene Schande (Anzahl, Status, Aufgabe).
 - Fortschritt-Tab im Offizier-Panel heißt jetzt "Mitglieder"; Rechtsklick auf einen Spieler öffnet ein Fenster mit dessen kompletter Schande-Historie (live abgefragt), inklusive Buttons zum direkten Verhängen und Aufheben.
 - Gildenpanel und Offizier-Panel teilen sich jetzt eine gemeinsame Tab-Leisten-Komponente.
+- Addon-Nachrichten werden jetzt gedrosselt versendet, um Verbindungsprobleme und Aussetzer bei vielen Online-Mitgliedern zu vermeiden.
+- Der "Anfordern"-Button im Fortschritt-Tab prüft jetzt auch gleich die Addon-Versionen mit; der separate "Versionen"-Button wurde entfernt.
 
 # 4.1.2
 

--- a/Debug.lua
+++ b/Debug.lua
@@ -212,7 +212,7 @@ function SchlingelInc.Debug:TestGuildRequest(targetName)
 	local message = string.format("INVITE_REQUEST:%s:%d:%d:%d:%d:%s",
 		playerName, playerLevel, playerExp, playerGold, runesKnown, zone)
 
-	C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, message, "WHISPER", targetName)
+	ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, message, "WHISPER", targetName, "SchlingelInc-Recruit")
 
 	SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS ..
 		"Test guild request sent to " .. targetName .. "|r")

--- a/Global.lua
+++ b/Global.lua
@@ -79,13 +79,16 @@ function SchlingelInc.Global:Initialize()
 				if sender then
 					SchlingelInc.guildMemberVersions[sender] = incomingVersion
 				end
+				if SchlingelInc.LevelUps and SchlingelInc.LevelUps.OnVersionReceived then
+					SchlingelInc.LevelUps.OnVersionReceived()
+				end
 				if SchlingelInc:CompareVersions(incomingVersion, newestVersionSeen) > 0 then
 					newestVersionSeen = incomingVersion
 					SchlingelInc:Print("Eine neue Version des Addons wurde gefunden: " ..
 						newestVersionSeen .. ". Bitte aktualisiere das Addon!")
 				end
 			elseif message == "VERSION_REQUEST" and IsInGuild() then
-				C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "VERSION:" .. SchlingelInc.version, "GUILD")
+				ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, "VERSION:" .. SchlingelInc.version, "GUILD", nil, "SchlingelInc-Version")
 			elseif message == "RULES_UPDATE" then
 				C_Timer.After(2, function()
 					SchlingelInc.Rules:LoadFromGuildInfo()
@@ -94,8 +97,8 @@ function SchlingelInc.Global:Initialize()
 		end, 0, "VersionChecker")
 
 	if IsInGuild() then
-		C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "VERSION:" .. SchlingelInc.version, "GUILD")
-		C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "VERSION_REQUEST", "GUILD")
+		ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, "VERSION:" .. SchlingelInc.version, "GUILD", nil, "SchlingelInc-Version")
+		ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, "VERSION_REQUEST", "GUILD", nil, "SchlingelInc-Version")
 	end
     C_GuildInfo.GuildRoster()
 end
@@ -223,7 +226,7 @@ function SchlingelInc:WriteGuildInfo(mail, ah, trade, group, blockedTrader, cap)
     SetGuildInfoText(newText)
     SchlingelInc:Print("Gildeninfo mit neuen Regeln aktualisiert.")
     SchlingelInc.Rules:LoadFromGuildInfo()
-    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "RULES_UPDATE", "GUILD")
+    ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, "RULES_UPDATE", "GUILD", nil, "SchlingelInc-Rules")
     return true
 end
 
@@ -255,7 +258,9 @@ end
 -- rather than silently aborting the rest of the calling event handler.
 function SchlingelInc:SendGuildChatMessage(text)
     if not text then return end
-    pcall(C_ChatInfo.SendChatMessage, text:sub(1, 250), "GUILD")
+    pcall(function()
+        ChatThrottleLib:SendChatMessage("NORMAL", SchlingelInc.prefix, text:sub(1, 250), "GUILD")
+    end)
 end
 
 -- Sanitizes text to prevent UI injection via escape codes.

--- a/GuildProfiles.lua
+++ b/GuildProfiles.lua
@@ -55,7 +55,7 @@ end
 function SchlingelInc.GuildProfiles:Broadcast()
     if not IsInGuild() then return end
     local payload = Serialize()
-    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, payload, "GUILD")
+    ChatThrottleLib:SendAddonMessage("NORMAL", SchlingelInc.prefix, payload, "GUILD", nil, "SchlingelInc-Profile")
     local ownProfile = Deserialize(payload:sub(#MSG_PROFILE + 2))
     local selfName = UnitName("player")
     if ownProfile and selfName then
@@ -125,7 +125,7 @@ function SchlingelInc.GuildProfiles:Initialize()
             C_Timer.After(6, function()
                 SchlingelInc.GuildProfiles:Broadcast()
                 if IsInGuild() then
-                    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "PROFILE_REQUEST", "GUILD")
+                    ChatThrottleLib:SendAddonMessage("NORMAL", SchlingelInc.prefix, "PROFILE_REQUEST", "GUILD", nil, "SchlingelInc-Profile")
                 end
             end)
         end, 90, "GuildProfilesBroadcast")
@@ -136,7 +136,7 @@ function SchlingelInc.GuildProfiles:Initialize()
             if IsInGuild() then
                 C_Timer.After(3, function()
                     SchlingelInc.GuildProfiles:Broadcast()
-                    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "PROFILE_REQUEST", "GUILD")
+                    ChatThrottleLib:SendAddonMessage("NORMAL", SchlingelInc.prefix, "PROFILE_REQUEST", "GUILD", nil, "SchlingelInc-Profile")
                 end)
             end
         end, 0, "GuildProfilesGuildUpdate")

--- a/GuildRecruitment.lua
+++ b/GuildRecruitment.lua
@@ -117,7 +117,7 @@ function SchlingelInc.GuildRecruitment:SendGuildRequest()
     wipe(pendingOfficerFilter)
     for _, name in ipairs(guildOfficers) do
         pendingOfficerFilter[name] = true
-        C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, message, "WHISPER", name)
+        ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, message, "WHISPER", name, "SchlingelInc-Recruit")
     end
     SchlingelInc:Print("Anfrage gesendet...")
     C_Timer.After(3, function() wipe(pendingOfficerFilter) end)
@@ -207,7 +207,7 @@ function SchlingelInc.GuildRecruitment:HandleAcceptRequest(playerName)
 
         local guildOfficers = GetAuthorizedOfficers()
         for _, name in ipairs(guildOfficers) do
-            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "INVITE_SENT:" .. playerName, "WHISPER", name)
+            ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, "INVITE_SENT:" .. playerName, "WHISPER", name, "SchlingelInc-Recruit")
         end
     end
 end
@@ -217,7 +217,7 @@ function SchlingelInc.GuildRecruitment:HandleDeclineRequest(playerName)
 
     local guildOfficers = GetAuthorizedOfficers()
     for _, name in ipairs(guildOfficers) do
-        C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "INVITE_DECLINED:" .. playerName, "WHISPER", name)
+        ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, "INVITE_DECLINED:" .. playerName, "WHISPER", name, "SchlingelInc-Recruit")
     end
 
     SchlingelInc.GuildRecruitment.inviteRequests[playerName] = nil

--- a/LevelUp.lua
+++ b/LevelUp.lua
@@ -53,12 +53,14 @@ local function SendProgressTo(targetName)
     if not entry then return end
 
     local xpStopSuffix = entry.xpStop ~= nil and (":" .. (entry.xpStop and "1" or "0")) or ""
-    C_ChatInfo.SendAddonMessage(
+    ChatThrottleLib:SendAddonMessage(
+        "NORMAL",
         SchlingelInc.prefix,
         string.format("PROGRESS:%s:%d:%d:%d:%d:%d%s",
             entry.name, entry.level, entry.xpCurrent, entry.xpMax, entry.gold, entry.runesKnown, xpStopSuffix),
         "WHISPER",
-        targetName
+        targetName,
+        "SchlingelInc-Progress"
     )
 end
 
@@ -70,7 +72,7 @@ local function CheckForMilestone(level)
             local handle = SchlingelInc:GetDiscordHandle()
             local playerDisplay = (handle and handle ~= "") and (player .. " (" .. handle .. ")") or player
             SchlingelInc:SendGuildChatMessage(playerDisplay .. " hat Level " .. level .. " erreicht! Schlingel! Schlingel! Schlingel!")
-            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "LEVELUP:" .. player .. ":" .. level, "GUILD")
+            ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, "LEVELUP:" .. player .. ":" .. level, "GUILD", nil, "SchlingelInc-Announce")
         end
     end
 end
@@ -80,12 +82,22 @@ function SchlingelInc.LevelUps:Initialize()
     local progressLoadReceived = 0
     local progressLoadTimer    = nil
 
+    local versionLoadTotal    = 0
+    local versionLoadReceived = 0
+    local versionLoadTimer    = nil
+
+    local function RefreshWhenLoadsDone()
+        if progressLoadTotal == 0 and versionLoadTotal == 0 then
+            SchlingelInc.OfficerPanel:RefreshProgress()
+        end
+    end
+
     local function EndProgressLoad()
         if progressLoadTimer then progressLoadTimer:Cancel() progressLoadTimer = nil end
         progressLoadTotal    = 0
         progressLoadReceived = 0
         if SchlingelInc.OfficerPanel and SchlingelInc.OfficerPanel.EndProgressLoad then SchlingelInc.OfficerPanel.EndProgressLoad() end
-        SchlingelInc.OfficerPanel:RefreshProgress()
+        RefreshWhenLoadsDone()
     end
 
     SchlingelInc.LevelUps.StartLoad = function(total)
@@ -106,6 +118,28 @@ function SchlingelInc.LevelUps:Initialize()
         end
         if progressLoadReceived >= progressLoadTotal then
             EndProgressLoad()
+        end
+    end
+
+    local function EndVersionLoad()
+        if versionLoadTimer then versionLoadTimer:Cancel() versionLoadTimer = nil end
+        versionLoadTotal    = 0
+        versionLoadReceived = 0
+        RefreshWhenLoadsDone()
+    end
+
+    SchlingelInc.LevelUps.StartVersionLoad = function(total)
+        versionLoadTotal    = total
+        versionLoadReceived = 0
+        if versionLoadTimer then versionLoadTimer:Cancel() end
+        versionLoadTimer = C_Timer.NewTimer(math.max(5, total * 0.1 + 5), EndVersionLoad)
+    end
+
+    SchlingelInc.LevelUps.OnVersionReceived = function()
+        if versionLoadTotal == 0 then return end
+        versionLoadReceived = versionLoadReceived + 1
+        if versionLoadReceived >= versionLoadTotal then
+            EndVersionLoad()
         end
     end
 
@@ -250,11 +284,10 @@ function SchlingelInc.LevelUps:RequestProgress(targetName)
 
     if targetName then
         SchlingelInc.LevelUps.StartLoad(1)
-        C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "PROGRESS_REQUEST", "WHISPER", targetName)
+        ChatThrottleLib:SendAddonMessage("NORMAL", SchlingelInc.prefix, "PROGRESS_REQUEST", "WHISPER", targetName, "SchlingelInc-Progress")
         return
     end
 
-    -- Staggered whispers to avoid simultaneous response flood
     local online = {}
     local selfName = UnitName("player")
     for i = 1, GetNumGuildMembers() or 0 do
@@ -267,10 +300,10 @@ function SchlingelInc.LevelUps:RequestProgress(targetName)
         end
     end
     SchlingelInc.LevelUps.StartLoad(#online)
-    for i, name in ipairs(online) do
-        C_Timer.After((i - 1) * 0.5, function()
-            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "PROGRESS_REQUEST", "WHISPER", name)
-        end)
+    SchlingelInc.LevelUps.StartVersionLoad(#online)
+    ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, "VERSION_REQUEST", "GUILD", nil, "SchlingelInc-Version")
+    for _, name in ipairs(online) do
+        ChatThrottleLib:SendAddonMessage("NORMAL", SchlingelInc.prefix, "PROGRESS_REQUEST", "WHISPER", name, "SchlingelInc-Progress")
     end
 end
 
@@ -292,7 +325,7 @@ function SchlingelInc.LevelUps:CheckForCap(level, announce)
             local handle = SchlingelInc:GetDiscordHandle()
             local playerDisplay = (handle and handle ~= "") and (player .. " (" .. handle .. ")") or player
             SchlingelInc:SendGuildChatMessage(playerDisplay .. " hat das Level Cap von " .. level .. " erreicht! Herzlichen Glückwunsch!")
-            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "CAP:" .. player .. ":" .. level, "GUILD")
+            ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, "CAP:" .. player .. ":" .. level, "GUILD", nil, "SchlingelInc-Announce")
         end
     end
 end

--- a/LevelUp.lua
+++ b/LevelUp.lua
@@ -52,12 +52,11 @@ local function SendProgressTo(targetName)
     local entry = BuildProgressEntry()
     if not entry then return end
 
-    local xpStopSuffix = entry.xpStop ~= nil and (":" .. (entry.xpStop and "1" or "0")) or ""
     ChatThrottleLib:SendAddonMessage(
         "NORMAL",
         SchlingelInc.prefix,
-        string.format("PROGRESS:%s:%d:%d:%d:%d:%d%s",
-            entry.name, entry.level, entry.xpCurrent, entry.xpMax, entry.gold, entry.runesKnown, xpStopSuffix),
+        string.format("PROGRESS:%s:%d:%d:%d:%d:%d:%d",
+            entry.name, entry.level, entry.xpCurrent, entry.xpMax, entry.gold, entry.runesKnown, entry.xpStop and 1 or 0),
         "WHISPER",
         targetName,
         "SchlingelInc-Progress"
@@ -205,30 +204,16 @@ function SchlingelInc.LevelUps:Initialize()
                 end
                 return
             end
-            local msgType, _, levelStr, xpCurrentStr, xpMaxStr, goldStr, field7, field8 = strsplit(":", message)
-            if msgType == "PROGRESS" and tonumber(levelStr) and tonumber(xpCurrentStr) and tonumber(xpMaxStr) and tonumber(goldStr) then
-                local runesKnown
-                local xpStop
-
-                -- Legacy format: PROGRESS:name:level:xpCurrent:xpMax:gold[:xpStop]
-                if field7 == "0" or field7 == "1" then
-                    xpStop = field7 == "1"
-                else
-                    -- New format: PROGRESS:name:level:xpCurrent:xpMax:gold:runesKnown[:xpStop]
-                    runesKnown = tonumber(field7)
-                    if field8 == "0" or field8 == "1" then
-                        xpStop = field8 == "1"
-                    end
-                end
-
+            local msgType, _, levelStr, xpCurrentStr, xpMaxStr, goldStr, runesStr, xpStopStr = strsplit(":", message)
+            if msgType == "PROGRESS" and tonumber(levelStr) and tonumber(xpCurrentStr) and tonumber(xpMaxStr) and tonumber(goldStr) and tonumber(runesStr) then
                 local shortName = SchlingelInc:RemoveRealmFromName(sender)
                 local entry = {
                     level      = tonumber(levelStr),
                     xpCurrent  = tonumber(xpCurrentStr),
                     xpMax      = tonumber(xpMaxStr),
                     gold       = tonumber(goldStr),
-                    runesKnown = runesKnown,
-                    xpStop     = xpStop,
+                    runesKnown = tonumber(runesStr),
+                    xpStop     = xpStopStr == "1",
                     timestamp  = time(),
                 }
                 SchlingelInc.LevelUps.progressCache[shortName] = entry

--- a/Schande.lua
+++ b/Schande.lua
@@ -55,7 +55,7 @@ function SchlingelInc.Schande:Impose(targetName, freetext)
     if not targetName or targetName == "" then return end
     freetext = freetext or ""
 
-    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, MSG_IMPOSE .. "|" .. freetext, "WHISPER", targetName)
+    ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, MSG_IMPOSE .. "|" .. freetext, "WHISPER", targetName, "SchlingelInc-Schande")
     SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS ..
         "Schande gegen " .. targetName .. " verhängt.|r")
 end
@@ -73,7 +73,7 @@ function SchlingelInc.Schande:Resolve(targetName, id)
         return
     end
 
-    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, MSG_RESOLVE .. "|" .. id, "WHISPER", targetName)
+    ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, MSG_RESOLVE .. "|" .. id, "WHISPER", targetName, "SchlingelInc-Schande")
     SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS ..
         "Schande #" .. id .. " von " .. targetName .. " aufgehoben.|r")
 end
@@ -98,7 +98,7 @@ function SchlingelInc.Schande:GetAllOf(targetName, callback)
         entries  = {},
     }
 
-    C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, MSG_FETCH, "WHISPER", targetName)
+    ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, MSG_FETCH, "WHISPER", targetName, "SchlingelInc-Schande")
 
     C_Timer.After(FETCH_TIMEOUT, function()
         if pendingFetch and pendingFetch.seq == seq then
@@ -150,11 +150,11 @@ function SchlingelInc.Schande:HandleMessage(message, sender)
 
     if message == MSG_FETCH then
         local entries = SchlingelOwnSchande.entries
-        C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, MSG_PUSH_COUNT .. "|" .. #entries, "WHISPER", sender)
+        ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, MSG_PUSH_COUNT .. "|" .. #entries, "WHISPER", sender, "SchlingelInc-Schande")
         for _, entry in ipairs(entries) do
-            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix,
+            ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix,
                 MSG_PUSH .. "|" .. entry.id .. "|" .. (entry.active and "1" or "0") .. "|" .. entry.freetext,
-                "WHISPER", sender)
+                "WHISPER", sender, "SchlingelInc-Schande")
         end
         return true
     end

--- a/SchlingelInc.toc
+++ b/SchlingelInc.toc
@@ -8,7 +8,8 @@
 ## SavedVariables: DiscordHandle, Pronouns, SchlingelGuildProfileCache, SchlingelGuildDB, SchlingelProgressDB
 
 # Notwendiges externe Abhängigkeiten aus dem Lib Folder
-## OptionalDeps: LibStub, CallbackHandler-1.0, LibDataBroker-1.1, LibDBIcon-1.0
+## OptionalDeps: LibStub, CallbackHandler-1.0, LibDataBroker-1.1, LibDBIcon-1.0, ChatThrottleLib-1.0
+libs\ChatThrottleLib-1.0\ChatThrottleLib-1.0.lua
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.lua
 libs\libdatabroker-1-1\LibDataBroker-1.1.lua

--- a/death/Death.lua
+++ b/death/Death.lua
@@ -161,7 +161,7 @@ function SchlingelInc.Death:Initialize()
 						zone,
 						SchlingelInc.DeathCauseHandler.DeathCause,
 					}, "|")
-					C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, addonDeathMsg, "GUILD")
+					ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, addonDeathMsg, "GUILD", nil, "SchlingelInc-Announce")
 				end
 			end
 

--- a/death/SlashCommands.lua
+++ b/death/SlashCommands.lua
@@ -39,6 +39,6 @@ SlashCmdList["DEATHSET"] = function(msg)
 		return
 	end
 
-	C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "DEATHSET|" .. tostring(inputValue), "WHISPER", targetName)
+	ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, "DEATHSET|" .. tostring(inputValue), "WHISPER", targetName, "SchlingelInc-Schande")
 	SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS .. "Deathset-Nachricht an " .. targetName .. " gesendet.|r")
 end

--- a/interfaces/OfficerPanel/TabProgress.lua
+++ b/interfaces/OfficerPanel/TabProgress.lua
@@ -101,7 +101,7 @@ function OfficerPanel.BuildProgressTab(pc)
     pOfflineBtn:SetScript("OnEnter", function() pOfflineLbl:SetTextColor(1, 1, 0.7, 1) end)
     pOfflineBtn:SetScript("OnLeave", UpdateOfflineBtn)
 
-    -- Left side: Lade-Indikator | Anfordern | Versionen | Filter
+    -- Left side: Lade-Indikator | Anfordern | Filter
     local pLoadFs = pc:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     pLoadFs:SetPoint("LEFT", pc, "TOPLEFT", 4, -11)
     pLoadFs:SetWidth(72)
@@ -115,16 +115,6 @@ function OfficerPanel.BuildProgressTab(pc)
     pRequestBtn:SetText("Anfordern")
     pRequestBtn:SetScript("OnClick", function()
         SchlingelInc.LevelUps:RequestProgress()
-    end)
-
-    local pVersionBtn = CreateFrame("Button", nil, pc, "UIPanelButtonTemplate")
-    pVersionBtn:SetSize(80, 18)
-    pVersionBtn:SetPoint("LEFT", pRequestBtn, "RIGHT", 4, 0)
-    pVersionBtn:SetText("Versionen")
-    pVersionBtn:SetScript("OnClick", function()
-        if IsInGuild() then
-            C_ChatInfo.SendAddonMessage(SchlingelInc.prefix, "VERSION_REQUEST", "GUILD")
-        end
     end)
 
     OfficerPanel.StartProgressLoad = function(total)
@@ -142,7 +132,7 @@ function OfficerPanel.BuildProgressTab(pc)
 
     local pfFilterBtn = CreateFrame("Button", nil, pc, "UIPanelButtonTemplate")
     pfFilterBtn:SetSize(60, 18)
-    pfFilterBtn:SetPoint("LEFT", pVersionBtn, "RIGHT", 4, 0)
+    pfFilterBtn:SetPoint("LEFT", pRequestBtn, "RIGHT", 4, 0)
     pfFilterBtn:SetText("Filter")
     pfFilterBtn:SetScript("OnClick", function()
         local fp = OfficerPanel.tabFilterPanels.progress

--- a/interfaces/OfficerPanel/TabProgress.lua
+++ b/interfaces/OfficerPanel/TabProgress.lua
@@ -320,7 +320,9 @@ function OfficerPanel.BuildProgressTab(pc)
                 va = tonumber(a[key]) or 0
                 vb = tonumber(b[key]) or 0
             end
-            if va ~= vb then return ascending and va < vb or va > vb end
+            if va ~= vb then
+                if ascending then return va < vb else return va > vb end
+            end
             local na = tostring(a.name or ""):lower()
             local nb = tostring(b.name or ""):lower()
             if na ~= nb then return na < nb end

--- a/libs/ChatThrottleLib-1.0/ChatThrottleLib-1.0.lua
+++ b/libs/ChatThrottleLib-1.0/ChatThrottleLib-1.0.lua
@@ -1,0 +1,688 @@
+--
+-- ChatThrottleLib by Mikk
+--
+-- Manages AddOn chat output to keep player from getting kicked off.
+--
+-- ChatThrottleLib:SendChatMessage/:SendAddonMessage functions that accept
+-- a Priority ("BULK", "NORMAL", "ALERT") as well as prefix for SendChatMessage.
+--
+-- Priorities get an equal share of available bandwidth when fully loaded.
+-- Communication channels are separated on extension+chattype+destination and
+-- get round-robinned. (Destination only matters for whispers and channels,
+-- obviously)
+--
+-- Will install hooks for SendChatMessage and SendAddonMessage to measure
+-- bandwidth bypassing the library and use less bandwidth itself.
+--
+--
+-- Fully embeddable library. Just copy this file into your addon directory,
+-- add it to the .toc, and it's done.
+--
+-- Can run as a standalone addon also, but, really, just embed it! :-)
+--
+-- LICENSE: ChatThrottleLib is released into the Public Domain
+--
+
+local CTL_VERSION = 29
+
+local _G = _G
+
+if _G.ChatThrottleLib then
+	if _G.ChatThrottleLib.version >= CTL_VERSION then
+		-- There's already a newer (or same) version loaded. Buh-bye.
+		return
+	elseif not _G.ChatThrottleLib.securelyHooked then
+		print("ChatThrottleLib: Warning: There's an ANCIENT ChatThrottleLib.lua (pre-wow 2.0, <v16) in an addon somewhere. Get the addon updated or copy in a newer ChatThrottleLib.lua (>=v16) in it!")
+		-- ATTEMPT to unhook; this'll behave badly if someone else has hooked...
+		-- ... and if someone has securehooked, they can kiss that goodbye too... >.<
+		_G.SendChatMessage = _G.ChatThrottleLib.ORIG_SendChatMessage
+		if _G.ChatThrottleLib.ORIG_SendAddonMessage then
+			_G.SendAddonMessage = _G.ChatThrottleLib.ORIG_SendAddonMessage
+		end
+	end
+	_G.ChatThrottleLib.ORIG_SendChatMessage = nil
+	_G.ChatThrottleLib.ORIG_SendAddonMessage = nil
+end
+
+if not _G.ChatThrottleLib then
+	_G.ChatThrottleLib = {}
+end
+
+ChatThrottleLib = _G.ChatThrottleLib  -- in case some addon does "local ChatThrottleLib" above us and we're copypasted (AceComm-2, sigh)
+local ChatThrottleLib = _G.ChatThrottleLib
+
+ChatThrottleLib.version = CTL_VERSION
+
+
+
+------------------ TWEAKABLES -----------------
+
+ChatThrottleLib.MAX_CPS = 800			  -- 2000 seems to be safe if NOTHING ELSE is happening. let's call it 800.
+ChatThrottleLib.MSG_OVERHEAD = 40		-- Guesstimate overhead for sending a message; source+dest+chattype+protocolstuff
+
+ChatThrottleLib.BURST = 4000				-- WoW's server buffer seems to be about 32KB. 8KB should be safe, but seen disconnects on _some_ servers. Using 4KB now.
+
+ChatThrottleLib.MIN_FPS = 20				-- Reduce output CPS to half (and don't burst) if FPS drops below this value
+
+
+local setmetatable = setmetatable
+local table_remove = table.remove
+local tostring = tostring
+local GetTime = GetTime
+local math_min = math.min
+local math_max = math.max
+local next = next
+local strlen = string.len
+local GetFramerate = GetFramerate
+local unpack,type,pairs,wipe = unpack,type,pairs,table.wipe
+
+
+-----------------------------------------------------------------------
+-- Double-linked ring implementation
+
+local Ring = {}
+local RingMeta = { __index = Ring }
+
+function Ring:New()
+	local ret = {}
+	setmetatable(ret, RingMeta)
+	return ret
+end
+
+function Ring:Add(obj)	-- Append at the "far end" of the ring (aka just before the current position)
+	if self.pos then
+		obj.prev = self.pos.prev
+		obj.prev.next = obj
+		obj.next = self.pos
+		obj.next.prev = obj
+	else
+		obj.next = obj
+		obj.prev = obj
+		self.pos = obj
+	end
+end
+
+function Ring:Remove(obj)
+	obj.next.prev = obj.prev
+	obj.prev.next = obj.next
+	if self.pos == obj then
+		self.pos = obj.next
+		if self.pos == obj then
+			self.pos = nil
+		end
+	end
+end
+
+-- Note that this is local because there's no upgrade logic for existing ring
+-- metatables, and this isn't present on rings created in versions older than
+-- v25.
+local function Ring_Link(self, other)  -- Move and append all contents of another ring to this ring
+	if not self.pos then
+		-- This ring is empty, so just transfer ownership.
+		self.pos = other.pos
+		other.pos = nil
+	elseif other.pos then
+		-- Our tail should point to their head, and their tail to our head.
+		self.pos.prev.next, other.pos.prev.next = other.pos, self.pos
+		-- Our head should point to their tail, and their head to our tail.
+		self.pos.prev, other.pos.prev = other.pos.prev, self.pos.prev
+		other.pos = nil
+	end
+end
+
+
+
+-----------------------------------------------------------------------
+-- Recycling bin for pipes
+-- A pipe is a plain integer-indexed queue of messages
+-- Pipes normally live in Rings of pipes  (3 rings total, one per priority)
+
+ChatThrottleLib.PipeBin = nil -- pre-v19, drastically different
+local PipeBin = setmetatable({}, {__mode="k"})
+
+local function DelPipe(pipe)
+	PipeBin[pipe] = true
+end
+
+local function NewPipe()
+	local pipe = next(PipeBin)
+	if pipe then
+		wipe(pipe)
+		PipeBin[pipe] = nil
+		return pipe
+	end
+	return {}
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Recycling bin for messages
+
+ChatThrottleLib.MsgBin = nil -- pre-v19, drastically different
+local MsgBin = setmetatable({}, {__mode="k"})
+
+local function DelMsg(msg)
+	msg[1] = nil
+	-- there's more parameters, but they're very repetetive so the string pool doesn't suffer really, and it's faster to just not delete them.
+	MsgBin[msg] = true
+end
+
+local function NewMsg()
+	local msg = next(MsgBin)
+	if msg then
+		MsgBin[msg] = nil
+		return msg
+	end
+	return {}
+end
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib:Init
+-- Initialize queues, set up frame for OnUpdate, etc
+
+
+function ChatThrottleLib:Init()
+
+	-- Set up queues
+	if not self.Prio then
+		self.Prio = {}
+		self.Prio["ALERT"] = { ByName = {}, Ring = Ring:New(), avail = 0 }
+		self.Prio["NORMAL"] = { ByName = {}, Ring = Ring:New(), avail = 0 }
+		self.Prio["BULK"] = { ByName = {}, Ring = Ring:New(), avail = 0 }
+	end
+
+	if not self.BlockedQueuesDelay then
+		-- v25: Add blocked queues to rings to handle new client throttles.
+		for _, Prio in pairs(self.Prio) do
+			Prio.Blocked = Ring:New()
+		end
+	end
+
+	-- v4: total send counters per priority
+	for _, Prio in pairs(self.Prio) do
+		Prio.nTotalSent = Prio.nTotalSent or 0
+	end
+
+	if not self.avail then
+		self.avail = 0 -- v5
+	end
+	if not self.nTotalSent then
+		self.nTotalSent = 0 -- v5
+	end
+
+
+	-- Set up a frame to get OnUpdate events
+	if not self.Frame then
+		self.Frame = CreateFrame("Frame")
+		self.Frame:Hide()
+	end
+	self.Frame:SetScript("OnUpdate", self.OnUpdate)
+	self.Frame:SetScript("OnEvent", self.OnEvent)	-- v11: Monitor P_E_W so we can throttle hard for a few seconds
+	self.Frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+	self.OnUpdateDelay = 0
+	self.BlockedQueuesDelay = 0
+	self.LastAvailUpdate = GetTime()
+	self.HardThrottlingBeginTime = GetTime()	-- v11: Throttle hard for a few seconds after startup
+
+	-- Hook SendChatMessage and SendAddonMessage so we can measure unpiped traffic and avoid overloads (v7)
+	if not self.securelyHooked then
+		-- Use secure hooks as of v16. Old regular hook support yanked out in v21.
+		self.securelyHooked = true
+		--SendChatMessage
+		hooksecurefunc("SendChatMessage", function(...)
+			return ChatThrottleLib.Hook_SendChatMessage(...)
+		end)
+		--SendAddonMessage
+		hooksecurefunc(_G.C_ChatInfo, "SendAddonMessage", function(...)
+			return ChatThrottleLib.Hook_SendAddonMessage(...)
+		end)
+	end
+
+	-- v26: Hook SendAddonMessageLogged for traffic logging
+	if not self.securelyHookedLogged then
+		self.securelyHookedLogged = true
+		hooksecurefunc(_G.C_ChatInfo, "SendAddonMessageLogged", function(...)
+			return ChatThrottleLib.Hook_SendAddonMessageLogged(...)
+		end)
+	end
+
+	-- v29: Hook BNSendGameData for traffic logging
+	if not self.securelyHookedBNGameData then
+		self.securelyHookedBNGameData = true
+		hooksecurefunc("BNSendGameData", function(...)
+			return ChatThrottleLib.Hook_BNSendGameData(...)
+		end)
+	end
+
+	self.nBypass = 0
+end
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib.Hook_SendChatMessage / .Hook_SendAddonMessage
+
+local bMyTraffic = false
+
+function ChatThrottleLib.Hook_SendChatMessage(text, chattype, language, destination, ...)
+	if bMyTraffic then
+		return
+	end
+	local self = ChatThrottleLib
+	local size = strlen(tostring(text or "")) + strlen(tostring(destination or "")) + self.MSG_OVERHEAD
+	self.avail = self.avail - size
+	self.nBypass = self.nBypass + size	-- just a statistic
+end
+function ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype, destination, ...)
+	if bMyTraffic then
+		return
+	end
+	local self = ChatThrottleLib
+	local size = tostring(text or ""):len() + tostring(prefix or ""):len();
+	size = size + tostring(destination or ""):len() + self.MSG_OVERHEAD
+	self.avail = self.avail - size
+	self.nBypass = self.nBypass + size	-- just a statistic
+end
+function ChatThrottleLib.Hook_SendAddonMessageLogged(prefix, text, chattype, destination, ...)
+	ChatThrottleLib.Hook_SendAddonMessage(prefix, text, chattype, destination, ...)
+end
+function ChatThrottleLib.Hook_BNSendGameData(destination, prefix, text)
+	ChatThrottleLib.Hook_SendAddonMessage(prefix, text, "WHISPER", destination)
+end
+
+
+
+-----------------------------------------------------------------------
+-- ChatThrottleLib:UpdateAvail
+-- Update self.avail with how much bandwidth is currently available
+
+function ChatThrottleLib:UpdateAvail()
+	local now = GetTime()
+	local MAX_CPS = self.MAX_CPS;
+	local newavail = MAX_CPS * (now - self.LastAvailUpdate)
+	local avail = self.avail
+
+	if now - self.HardThrottlingBeginTime < 5 then
+		-- First 5 seconds after startup/zoning: VERY hard clamping to avoid irritating the server rate limiter, it seems very cranky then
+		avail = math_min(avail + (newavail*0.1), MAX_CPS*0.5)
+		self.bChoking = true
+	elseif GetFramerate() < self.MIN_FPS then		-- GetFrameRate call takes ~0.002 secs
+		avail = math_min(MAX_CPS, avail + newavail*0.5)
+		self.bChoking = true		-- just a statistic
+	else
+		avail = math_min(self.BURST, avail + newavail)
+		self.bChoking = false
+	end
+
+	avail = math_max(avail, 0-(MAX_CPS*2))	-- Can go negative when someone is eating bandwidth past the lib. but we refuse to stay silent for more than 2 seconds; if they can do it, we can.
+
+	self.avail = avail
+	self.LastAvailUpdate = now
+
+	return avail
+end
+
+
+-----------------------------------------------------------------------
+-- Despooling logic
+-- Reminder:
+-- - We have 3 Priorities, each containing a "Ring" construct ...
+-- - ... made up of N "Pipe"s (1 for each destination/pipename)
+-- - and each pipe contains messages
+
+local SendAddonMessageResult = Enum.SendAddonMessageResult or {
+	Success = 0,
+	AddonMessageThrottle = 3,
+	NotInGroup = 5,
+	ChannelThrottle = 8,
+	GeneralError = 9,
+}
+
+local function MapToSendResult(ok, ...)
+	local result
+
+	if not ok then
+		-- The send function itself errored; don't look at anything else.
+		result = SendAddonMessageResult.GeneralError
+	else
+		-- Grab the last return value from the send function and remap
+		-- it from a boolean to an enum code. If there are no results,
+		-- assume success (true).
+
+		result = select(-1, true, ...)
+
+		if result == true then
+			result = SendAddonMessageResult.Success
+		elseif result == false then
+			result = SendAddonMessageResult.GeneralError
+		end
+	end
+
+	return result
+end
+
+local function IsThrottledSendResult(result)
+	return result == SendAddonMessageResult.AddonMessageThrottle
+end
+
+-- A copy of this function exists in FrameXML, but for clarity it's here too.
+local function CallErrorHandler(...)
+	return geterrorhandler()(...)
+end
+
+local function PerformSend(sendFunction, ...)
+	bMyTraffic = true
+	local sendResult = MapToSendResult(xpcall(sendFunction, CallErrorHandler, ...))
+	bMyTraffic = false
+	return sendResult
+end
+
+function ChatThrottleLib:Despool(Prio)
+	local ring = Prio.Ring
+	while ring.pos and Prio.avail > ring.pos[1].nSize do
+		local pipe = ring.pos
+		local msg = pipe[1]
+		local sendResult = PerformSend(msg.f, unpack(msg, 1, msg.n))
+
+		if IsThrottledSendResult(sendResult) then
+			-- Message was throttled; move the pipe into the blocked ring.
+			Prio.Ring:Remove(pipe)
+			Prio.Blocked:Add(pipe)
+		else
+			-- Dequeue message after submission.
+			table_remove(pipe, 1)
+			DelMsg(msg)
+
+			if not pipe[1] then  -- did we remove last msg in this pipe?
+				Prio.Ring:Remove(pipe)
+				Prio.ByName[pipe.name] = nil
+				DelPipe(pipe)
+			else
+				ring.pos = ring.pos.next
+			end
+
+			-- Update bandwidth counters on successful sends.
+			local didSend = (sendResult == SendAddonMessageResult.Success)
+			if didSend then
+				Prio.avail = Prio.avail - msg.nSize
+				Prio.nTotalSent = Prio.nTotalSent + msg.nSize
+			end
+
+			-- Notify caller of message submission.
+			if msg.callbackFn then
+				securecallfunction(msg.callbackFn, msg.callbackArg, didSend, sendResult)
+			end
+		end
+	end
+end
+
+
+function ChatThrottleLib.OnEvent(this,event)
+	-- v11: We know that the rate limiter is touchy after login. Assume that it's touchy after zoning, too.
+	local self = ChatThrottleLib
+	if event == "PLAYER_ENTERING_WORLD" then
+		self.HardThrottlingBeginTime = GetTime()	-- Throttle hard for a few seconds after zoning
+		self.avail = 0
+	end
+end
+
+
+function ChatThrottleLib.OnUpdate(this,delay)
+	local self = ChatThrottleLib
+
+	self.OnUpdateDelay = self.OnUpdateDelay + delay
+	self.BlockedQueuesDelay = self.BlockedQueuesDelay + delay
+	if self.OnUpdateDelay < 0.08 then
+		return
+	end
+	self.OnUpdateDelay = 0
+
+	self:UpdateAvail()
+
+	if self.avail < 0  then
+		return -- argh. some bastard is spewing stuff past the lib. just bail early to save cpu.
+	end
+
+	-- Integrate blocked queues back into their rings periodically.
+	if self.BlockedQueuesDelay >= 0.35 then
+		for _, Prio in pairs(self.Prio) do
+			Ring_Link(Prio.Ring, Prio.Blocked)
+		end
+
+		self.BlockedQueuesDelay = 0
+	end
+
+	-- See how many of our priorities have queued messages. This is split
+	-- into two counters because priorities that consist only of blocked
+	-- queues must keep our OnUpdate alive, but shouldn't count toward
+	-- bandwidth distribution.
+	local nSendablePrios = 0
+	local nBlockedPrios = 0
+
+	for prioname, Prio in pairs(self.Prio) do
+		if Prio.Ring.pos then
+			nSendablePrios = nSendablePrios + 1
+		elseif Prio.Blocked.pos then
+			nBlockedPrios = nBlockedPrios + 1
+		end
+
+		-- Collect unused bandwidth from priorities with nothing to send.
+		if not Prio.Ring.pos then
+			self.avail = self.avail + Prio.avail
+			Prio.avail = 0
+		end
+	end
+
+	-- Bandwidth reclamation may take us back over the burst cap.
+	self.avail = math_min(self.avail, self.BURST)
+
+	-- If we can't currently send on any priorities, stop processing early.
+	if nSendablePrios == 0 then
+		-- If we're completely out of data to send, disable queue processing.
+		if nBlockedPrios == 0 then
+			self.bQueueing = false
+			self.Frame:Hide()
+		end
+
+		return
+	end
+
+	-- There's stuff queued. Hand out available bandwidth to priorities as needed and despool their queues
+	local avail = self.avail / nSendablePrios
+	self.avail = 0
+
+	for prioname, Prio in pairs(self.Prio) do
+		if Prio.Ring.pos then
+			Prio.avail = Prio.avail + avail
+			self:Despool(Prio)
+		end
+	end
+end
+
+
+
+
+-----------------------------------------------------------------------
+-- Spooling logic
+
+function ChatThrottleLib:Enqueue(prioname, pipename, msg)
+	local Prio = self.Prio[prioname]
+	local pipe = Prio.ByName[pipename]
+	if not pipe then
+		self.Frame:Show()
+		pipe = NewPipe()
+		pipe.name = pipename
+		Prio.ByName[pipename] = pipe
+		Prio.Ring:Add(pipe)
+	end
+
+	pipe[#pipe + 1] = msg
+
+	self.bQueueing = true
+end
+
+function ChatThrottleLib:SendChatMessage(prio, prefix,   text, chattype, language, destination, queueName, callbackFn, callbackArg)
+	if not self or not prio or not prefix or not text or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:SendChatMessage("{BULK||NORMAL||ALERT}", "prefix", "text"[, "chattype"[, "language"[, "destination"]]]', 2)
+	end
+	if callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:ChatMessage(): callbackFn: expected function, got '..type(callbackFn), 2)
+	end
+
+	local nSize = text:len()
+
+	if nSize>255 then
+		error("ChatThrottleLib:SendChatMessage(): message length cannot exceed 255 bytes", 2)
+	end
+
+	nSize = nSize + self.MSG_OVERHEAD
+
+	-- Check if there's room in the global available bandwidth gauge to send directly
+	if not self.bQueueing and nSize < self:UpdateAvail() then
+		local sendResult = PerformSend(_G.SendChatMessage, text, chattype, language, destination)
+
+		if not IsThrottledSendResult(sendResult) then
+			local didSend = (sendResult == SendAddonMessageResult.Success)
+
+			if didSend then
+				self.avail = self.avail - nSize
+				self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize
+			end
+
+			if callbackFn then
+				securecallfunction(callbackFn, callbackArg, didSend, sendResult)
+			end
+
+			return
+		end
+	end
+
+	-- Message needs to be queued
+	local msg = NewMsg()
+	msg.f = _G.SendChatMessage
+	msg[1] = text
+	msg[2] = chattype or "SAY"
+	msg[3] = language
+	msg[4] = destination
+	msg.n = 4
+	msg.nSize = nSize
+	msg.callbackFn = callbackFn
+	msg.callbackArg = callbackArg
+
+	self:Enqueue(prio, queueName or prefix, msg)
+end
+
+
+local function SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+	local nSize = #text + self.MSG_OVERHEAD
+
+	-- Check if there's room in the global available bandwidth gauge to send directly
+	if not self.bQueueing and nSize < self:UpdateAvail() then
+		local sendResult = PerformSend(sendFunction, prefix, text, chattype, target)
+
+		if not IsThrottledSendResult(sendResult) then
+			local didSend = (sendResult == SendAddonMessageResult.Success)
+
+			if didSend then
+				self.avail = self.avail - nSize
+				self.Prio[prio].nTotalSent = self.Prio[prio].nTotalSent + nSize
+			end
+
+			if callbackFn then
+				securecallfunction(callbackFn, callbackArg, didSend, sendResult)
+			end
+
+			return
+		end
+	end
+
+	-- Message needs to be queued
+	local msg = NewMsg()
+	msg.f = sendFunction
+	msg[1] = prefix
+	msg[2] = text
+	msg[3] = chattype
+	msg[4] = target
+	msg.n = (target~=nil) and 4 or 3;
+	msg.nSize = nSize
+	msg.callbackFn = callbackFn
+	msg.callbackArg = callbackArg
+
+	self:Enqueue(prio, queueName or prefix, msg)
+end
+
+
+function ChatThrottleLib:SendAddonMessage(prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+	if not self or not prio or not prefix or not text or not chattype or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:SendAddonMessage("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype"[, "target"])', 2)
+	elseif callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:SendAddonMessage(): callbackFn: expected function, got '..type(callbackFn), 2)
+	elseif #text>255 then
+		error("ChatThrottleLib:SendAddonMessage(): message length cannot exceed 255 bytes", 2)
+	end
+
+	local sendFunction = _G.C_ChatInfo.SendAddonMessage
+	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+end
+
+
+function ChatThrottleLib:SendAddonMessageLogged(prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+	if not self or not prio or not prefix or not text or not chattype or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:SendAddonMessageLogged("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype"[, "target"])', 2)
+	elseif callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:SendAddonMessageLogged(): callbackFn: expected function, got '..type(callbackFn), 2)
+	elseif #text>255 then
+		error("ChatThrottleLib:SendAddonMessageLogged(): message length cannot exceed 255 bytes", 2)
+	end
+
+	local sendFunction = _G.C_ChatInfo.SendAddonMessageLogged
+	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, target, queueName, callbackFn, callbackArg)
+end
+
+local function BNSendGameDataReordered(prefix, text, _, gameAccountID)
+	return _G.BNSendGameData(gameAccountID, prefix, text)
+end
+
+function ChatThrottleLib:BNSendGameData(prio, prefix, text, chattype, gameAccountID, queueName, callbackFn, callbackArg)
+	-- Note that this API is intentionally limited to 255 bytes of data
+	-- for reasons of traffic fairness, which is less than the 4078 bytes
+	-- BNSendGameData natively supports. Additionally, a chat type is required
+	-- but must always be set to 'WHISPER' to match what is exposed by the
+	-- receipt event.
+	--
+	-- If splitting messages, callers must also be aware that message
+	-- delivery over BNSendGameData is unordered.
+
+	if not self or not prio or not prefix or not text or not gameAccountID or not chattype or not self.Prio[prio] then
+		error('Usage: ChatThrottleLib:BNSendGameData("{BULK||NORMAL||ALERT}", "prefix", "text", "chattype", gameAccountID)', 2)
+	elseif callbackFn and type(callbackFn)~="function" then
+		error('ChatThrottleLib:BNSendGameData(): callbackFn: expected function, got '..type(callbackFn), 2)
+	elseif #text>255 then
+		error("ChatThrottleLib:BNSendGameData(): message length cannot exceed 255 bytes", 2)
+	elseif chattype ~= "WHISPER" then
+		error("ChatThrottleLib:BNSendGameData(): chat type must be 'WHISPER'", 2)
+	end
+
+	local sendFunction = BNSendGameDataReordered
+	SendAddonMessageInternal(self, sendFunction, prio, prefix, text, chattype, gameAccountID, queueName, callbackFn, callbackArg)
+end
+
+
+-----------------------------------------------------------------------
+-- Get the ball rolling!
+
+ChatThrottleLib:Init()
+
+--[[ WoWBench debugging snippet
+if(WOWB_VER) then
+	local function SayTimer()
+		print("SAY: "..GetTime().." "..arg1)
+	end
+	ChatThrottleLib.Frame:SetScript("OnEvent", SayTimer)
+	ChatThrottleLib.Frame:RegisterEvent("CHAT_MSG_SAY")
+end
+]]
+
+


### PR DESCRIPTION
## Zusammenfassung
- Alle Addon-Nachrichten (SendAddonMessage/SendChatMessage) laufen jetzt über ChatThrottleLib statt direkt über die Blizzard-API
- Verhindert verlorene Nachrichten und Lags bei vielen Online-Mitgliedern (z.B. Schande-Fetch, Fortschritts-Anfrage an die ganze Gilde)
- "Anfordern" im Mitglieder-Tab prüft jetzt auch die Version mit; separater "Versionen"-Button entfernt
- Bugfix: Sortierung im Mitglieder-Tab war in aufsteigender Reihenfolge kaputt (sortierte immer absteigend)
- Bugfix: Runenanzahl von 0 oder 1 wurde durch mehrdeutiges Legacy-Parsing verschluckt

## Testplan
- [x] Schande-Fetch mit vielen Einträgen kommt vollständig beim Offizier an
- [x] "Anfordern" mit 40+ Online-Mitgliedern lädt Fortschritt + Version zügig
- [x] Sortierung nach Name/Level/etc. auf- und absteigend korrekt
- [x] Runenanzahl 0/1 wird korrekt übertragen

Closes #130