### PR TITLE
Rechtsklickmenü im Mitglieder-Tab (Schande-Ansicht, Deathset)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 4.1.3
 
 - Neuer "Schande"-Tab im Gildenpanel: zeigt die eigene Schande (Anzahl, Status, Aufgabe).
-- Fortschritt-Tab im Offizier-Panel heißt jetzt "Mitglieder"; Rechtsklick auf einen Spieler öffnet ein Fenster mit dessen kompletter Schande-Historie (live abgefragt), inklusive Buttons zum direkten Verhängen und Aufheben.
+- Fortschritt-Tab im Offizier-Panel heißt jetzt "Mitglieder"; Rechtsklick auf einen Spieler öffnet ein Kontextmenü mit "Schande-Ansicht öffnen" (zeigt die komplette Schande-Historie live abgefragt, inklusive Buttons zum direkten Verhängen und Aufheben) und "Deathset setzen".
 - Gildenpanel und Offizier-Panel teilen sich jetzt eine gemeinsame Tab-Leisten-Komponente.
 - Addon-Nachrichten werden jetzt gedrosselt versendet, um Verbindungsprobleme und Aussetzer bei vielen Online-Mitgliedern zu vermeiden.
 - Der "Anfordern"-Button im Fortschritt-Tab prüft jetzt auch gleich die Addon-Versionen mit; der separate "Versionen"-Button wurde entfernt.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Alle Tode werden in der Gilde geteilt und angezeigt.
   - Tooltip mit vollständigen Details beim Hover (Discord Handle, Zone, Todesursache, Letzte Worte)
   - Größe anpassbar: 250x120 Minimum bis 500x350 Maximum
   - Speichert Position und Größe automatisch
-- **Slash Command:** `/deathset <nummer>` zum manuellen Setzen des Todeszählers
+- **Todeszähler setzen:** Offiziere können im Mitglieder-Tab per Rechtsklick auf einen Spieler "Deathset setzen" wählen
 
 ### Levelbenachrichtigungen
 
@@ -182,7 +182,7 @@ Das Addon hat einige optionale Einstellungen die du im WoW Options-Menü unter "
 - **Discord Handle:** Wird automatisch beim ersten Login abgefragt und in der Gildennotiz gespeichert
 - **Discord Handle ändern:** `/setHandle <handle>` um den Discord Handle zu ändern
 - **Gildenbeitritt:** Linksklick auf Minimap-Icon – erst Profil einrichten, dann Beitrittsanfrage senden
-- **Todeszähler setzen:** `/deathset <nummer>` um den Zähler manuell anzupassen
+- **Todeszähler setzen:** Rechtsklick auf einen Spieler im Mitglieder-Tab (Offizier-Panel) → "Deathset setzen"
 
 ---
 

--- a/SchlingelInc.toc
+++ b/SchlingelInc.toc
@@ -54,6 +54,7 @@ interfaces\OfficerPanel\TabDiscord.lua
 interfaces\OfficerPanel\TabInvites.lua
 interfaces\OfficerPanel\Filters.lua
 interfaces\OfficerPanel\SchandeViewer.lua
+interfaces\OfficerPanel\MemberContextMenu.lua
 interfaces\GuildPanel\init.lua
 interfaces\GuildPanel\Data.lua
 interfaces\GuildPanel\Rows.lua

--- a/death/SlashCommands.lua
+++ b/death/SlashCommands.lua
@@ -14,31 +14,25 @@ function SchlingelInc.DeathSlashCommands:Initialize()
         end, 0, "DeathSetReceive")
 end
 
--- Define slash command
-SLASH_DEATHSET1 = '/deathset'
-SlashCmdList["DEATHSET"] = function(msg)
+function SchlingelInc.Death:SetRemote(targetName, valueStr)
 	if not CanGuildInvite() then
 		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Keine Berechtigung für diesen Befehl.|r")
 		return
 	end
 
-	local targetName, valueStr = msg:match("^(%S+)%s+(%S+)$")
-	if not targetName or not valueStr then
-		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Verwendung: /deathset <Spielername> <Zahl>|r")
+	if not targetName or targetName == "" then return end
+
+	local value = tonumber(valueStr)
+	if not value then
+		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Ungültige Zahl: " .. tostring(valueStr) .. "|r")
 		return
 	end
 
-	local inputValue = tonumber(valueStr)
-	if not inputValue then
-		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Ungültige Zahl: " .. valueStr .. "|r")
-		return
-	end
-
-	if inputValue < 0 or inputValue > 999999 then
+	if value < 0 or value > 999999 then
 		SchlingelInc:Print(SchlingelInc.Constants.COLORS.ERROR .. "Wert muss zwischen 0 und 999999 liegen.|r")
 		return
 	end
 
-	ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, "DEATHSET|" .. tostring(inputValue), "WHISPER", targetName, "SchlingelInc-Schande")
+	ChatThrottleLib:SendAddonMessage("ALERT", SchlingelInc.prefix, "DEATHSET|" .. tostring(value), "WHISPER", targetName, "SchlingelInc-Schande")
 	SchlingelInc:Print(SchlingelInc.Constants.COLORS.SUCCESS .. "Deathset-Nachricht an " .. targetName .. " gesendet.|r")
 end

--- a/interfaces/OfficerPanel/MemberContextMenu.lua
+++ b/interfaces/OfficerPanel/MemberContextMenu.lua
@@ -1,0 +1,61 @@
+local OfficerPanel = SchlingelInc.OfficerPanel
+
+StaticPopupDialogs["SCHLINGEL_DEATHSET_SET"] = {
+    text = "Deathcounter für %s setzen:",
+    button1 = "Setzen",
+    button2 = "Abbrechen",
+    hasEditBox = true,
+    maxLetters = 6,
+    OnShow = function(self)
+        self.EditBox:SetText("")
+        self.EditBox:SetFocus()
+    end,
+    OnAccept = function(self)
+        SchlingelInc.Death:SetRemote(self.data, self.EditBox:GetText())
+    end,
+    EditBoxOnEnterPressed = function(self)
+        self:GetParent().button1:Click()
+    end,
+    EditBoxOnEscapePressed = function(self)
+        self:GetParent():Hide()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+local contextMenu = CreateFrame("Frame", "SchlingelIncMemberContextMenu", UIParent, "UIDropDownMenuTemplate")
+local contextMenuTarget = nil
+
+UIDropDownMenu_Initialize(contextMenu, function(self, level)
+    if not contextMenuTarget then return end
+    local targetName = contextMenuTarget
+
+    local info = UIDropDownMenu_CreateInfo()
+    info.notCheckable = true
+
+    info.text = "Schande-Ansicht öffnen"
+    info.func = function()
+        CloseDropDownMenus()
+        OfficerPanel:ShowSchandeViewer(targetName)
+    end
+    UIDropDownMenu_AddButton(info, level)
+
+    info = UIDropDownMenu_CreateInfo()
+    info.notCheckable = true
+    info.text = "Deathset setzen"
+    info.func = function()
+        CloseDropDownMenus()
+        StaticPopup_Show("SCHLINGEL_DEATHSET_SET", targetName, nil, targetName)
+    end
+    UIDropDownMenu_AddButton(info, level)
+end, "MENU")
+
+-- Public API
+
+function OfficerPanel:ShowMemberContextMenu(targetName)
+    if not targetName or targetName == "" then return end
+    contextMenuTarget = targetName
+    ToggleDropDownMenu(1, nil, contextMenu, "cursor", 0, 0)
+end

--- a/interfaces/OfficerPanel/TabProgress.lua
+++ b/interfaces/OfficerPanel/TabProgress.lua
@@ -366,7 +366,7 @@ function OfficerPanel.BuildProgressTab(pc)
                 if btn == "LeftButton" then
                     SchlingelInc.LevelUps:RequestProgress(entry.name)
                 elseif btn == "RightButton" then
-                    SchlingelInc.OfficerPanel:ShowSchandeViewer(entry.name)
+                    SchlingelInc.OfficerPanel:ShowMemberContextMenu(entry.name)
                 end
             end)
 


### PR DESCRIPTION
Closes #132

## Summary
- Rechtsklick auf eine Zeile im Mitglieder-Tab öffnet jetzt ein Kontextmenü mit "Schande-Ansicht öffnen" und "Deathset setzen" statt direkt die Schande-Ansicht.
- `/deathset` entfällt, die Validierung/Versand-Logik liegt jetzt in `SchlingelInc.Death:SetRemote`.

## Test plan
- [x] Rechtsklick auf eine Zeile im Mitglieder-Tab öffnet das Menü
- [x] "Schande-Ansicht öffnen" zeigt weiterhin die Schande-Historie
- [x] "Deathset setzen" → Popup → Wert setzen sendet die Whisper-Nachricht korrekt
- [x] Ungültige Eingaben (leer, außerhalb 0-999999) zeigen die Fehlermeldung