### PR TITLE
Fix #141: Dropdown-Menüs/Listen schließen bei Klick außerhalb

### DIFF
--- a/Global.lua
+++ b/Global.lua
@@ -53,6 +53,52 @@ function SchlingelInc:RegisterFrameForEscape(frame)
     table.insert(UISpecialFrames, frameName)
 end
 
+-- Closes a floating dropdown-style list on any click outside it, and whenever
+-- ownerFrame (the popup/panel it belongs to) is hidden. listFrame must use a
+-- higher strata than "FULLSCREEN_DIALOG" (e.g. "TOOLTIP", the convention used by
+-- every dropdown list in this addon) so the catcher never swallows item clicks.
+function SchlingelInc:RegisterOutsideClickClose(listFrame, ownerFrame)
+    local catcher = CreateFrame("Button", nil, UIParent)
+    catcher:SetAllPoints(UIParent)
+    catcher:SetFrameStrata("FULLSCREEN_DIALOG")
+    catcher:EnableMouse(true)
+    catcher:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+    catcher:Hide()
+    catcher:SetScript("OnClick", function() listFrame:Hide() end)
+
+    listFrame:HookScript("OnShow", function() catcher:Show() end)
+    listFrame:HookScript("OnHide", function() catcher:Hide() end)
+    if ownerFrame then
+        ownerFrame:HookScript("OnHide", function() listFrame:Hide() end)
+    end
+end
+
+-- Closes a Blizzard UIDropDownMenuTemplate dropdown (context menu or combo box) on any
+-- click outside it — needed because clicking another same/higher-strata addon frame
+-- (e.g. our own panels) eats the click before Blizzard's own auto-close logic ever sees
+-- it. onCloseFn (optional) runs extra cleanup whenever the dropdown closes.
+function SchlingelInc:RegisterDropdownAutoClose(dropdownFrame, onCloseFn)
+    if not DropDownList1 then return end
+
+    local catcher = CreateFrame("Button", nil, UIParent)
+    catcher:SetAllPoints(UIParent)
+    catcher:SetFrameStrata("DIALOG")
+    catcher:EnableMouse(true)
+    catcher:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+    catcher:Hide()
+    catcher:SetScript("OnClick", CloseDropDownMenus)
+
+    DropDownList1:HookScript("OnShow", function()
+        if UIDROPDOWNMENU_OPEN_MENU == dropdownFrame then
+            catcher:Show()
+        end
+    end)
+    DropDownList1:HookScript("OnHide", function()
+        catcher:Hide()
+        if onCloseFn then onCloseFn() end
+    end)
+end
+
 SchlingelInc.lastPvPAlert = {}
 
 SchlingelInc.Global = {}

--- a/interfaces/FilterPanel.lua
+++ b/interfaces/FilterPanel.lua
@@ -43,9 +43,6 @@ function SchlingelInc.Shared.CreateFilterPanel(cfg)
     fp:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
     fp:SetPoint("TOPLEFT", anchor, "TOPRIGHT", 6, 0)
     fp:Hide()
-    fp:SetScript("OnHide", function()
-        if fp.profList then fp.profList:Hide() end
-    end)
     SchlingelInc:RegisterFrameForEscape(fp)
 
     -- ── Title ────────────────────────────────────────────────────────────────
@@ -233,6 +230,7 @@ function SchlingelInc.Shared.CreateFilterPanel(cfg)
 
         prevWidget  = profBtn
         fp.profList = profList
+        SchlingelInc:RegisterOutsideClickClose(profList, fp)
     end
 
     -- ── Reset ─────────────────────────────────────────────────────────────────

--- a/interfaces/OfficerPanel/MemberContextMenu.lua
+++ b/interfaces/OfficerPanel/MemberContextMenu.lua
@@ -40,26 +40,8 @@ StaticPopupDialogs["SCHLINGEL_DEATHSET_SET"] = {
 
 local contextMenu = CreateFrame("Frame", "SchlingelIncMemberContextMenu", UIParent, "UIDropDownMenuTemplate")
 local contextMenuTarget = nil
-local contextMenuClickCatcher = CreateFrame("Button", nil, UIParent)
 
-contextMenuClickCatcher:SetAllPoints(UIParent)
-contextMenuClickCatcher:SetFrameStrata("HIGH")
-contextMenuClickCatcher:EnableMouse(true)
-contextMenuClickCatcher:RegisterForClicks("LeftButtonUp", "RightButtonUp")
-contextMenuClickCatcher:SetScript("OnClick", function()
-    CloseDropDownMenus()
-    contextMenuClickCatcher:Hide()
-    contextMenuTarget = nil
-end)
-contextMenuClickCatcher:Hide()
-
-if DropDownList1 and not DropDownList1.SchlingelIncCloseHooked then
-    DropDownList1:HookScript("OnHide", function()
-        contextMenuClickCatcher:Hide()
-        contextMenuTarget = nil
-    end)
-    DropDownList1.SchlingelIncCloseHooked = true
-end
+SchlingelInc:RegisterDropdownAutoClose(contextMenu, function() contextMenuTarget = nil end)
 
 UIDropDownMenu_Initialize(contextMenu, function(self, level)
     if not contextMenuTarget then return end
@@ -109,10 +91,4 @@ function OfficerPanel:ShowMemberContextMenu(targetName)
     if not targetName or targetName == "" then return end
     contextMenuTarget = targetName
     ToggleDropDownMenu(1, nil, contextMenu, "cursor", 0, 0)
-    if DropDownList1 and DropDownList1:IsShown() then
-        contextMenuClickCatcher:Show()
-    else
-        contextMenuClickCatcher:Hide()
-        contextMenuTarget = nil
-    end
 end

--- a/interfaces/OfficerPanel/TabRules.lua
+++ b/interfaces/OfficerPanel/TabRules.lua
@@ -20,6 +20,7 @@ function OfficerPanel.BuildRulesTab(rc)
     local mailDropdown = CreateFrame("Frame", "SchlingelIncMailDropdown", rc, "UIDropDownMenuTemplate")
     mailDropdown:SetPoint("TOPLEFT", rc, "TOPLEFT", 140, -5)
     UIDropDownMenu_SetWidth(mailDropdown, 235)
+    SchlingelInc:RegisterDropdownAutoClose(mailDropdown)
     UIDropDownMenu_Initialize(mailDropdown, function()
         for _, option in ipairs(mailRuleOptions) do
             local value, label = option.value, option.label

--- a/interfaces/popups/AchievementForm.lua
+++ b/interfaces/popups/AchievementForm.lua
@@ -126,6 +126,7 @@ local function BuildForm()
     kindList:SetPoint("TOPLEFT", kindBtn, "BOTTOMLEFT", 0, -2)
     kindList:Hide()
     f.kindList = kindList
+    SchlingelInc:RegisterOutsideClickClose(kindList, f)
 
     -- ── Kriterien (dynamic per kind, all anchored at the same point) ────────
     local criteriaAnchor = CreateFrame("Frame", nil, f)

--- a/interfaces/popups/RaidPostForm.lua
+++ b/interfaces/popups/RaidPostForm.lua
@@ -93,6 +93,7 @@ local function BuildForm()
     instList:SetPoint("TOPLEFT", instBtn, "BOTTOMLEFT", 0, -2)
     instList:Hide()
     f.instList = instList
+    SchlingelInc:RegisterOutsideClickClose(instList, f)
 
     local ITEM_H = 18
     local yOff   = -4


### PR DESCRIPTION
Closes #141.

Zwei gemeinsame Helper (`RegisterOutsideClickClose`, `RegisterDropdownAutoClose`) in `Global.lua`. Betroffen waren Context-Menü, mailDropdown (Regeln-Tab), sowie Raid-Instanz-, Achievement-Art- und Berufs-Auswahl.