### PR TITLE
Fix #138: Raid-Teilnehmende manuell hinzufügen/entfernen

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -138,6 +138,33 @@ SchlingelInc.Constants.POPUPBACKDROP = {
 	insets = { left = 4, right = 4, top = 4, bottom = 4 }
 }
 
+-- Floating dropdown/suggestion list backdrop (instance/kind/profession/name pickers)
+SchlingelInc.Constants.DROPDOWNBACKDROP = {
+	bgFile = "Interface\\BUTTONS\\WHITE8X8",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile = true, tileSize = 16, edgeSize = 16,
+	insets = { left = 4, right = 4, top = 4, bottom = 4 }
+}
+
+-- Shared widget colors for popup forms (title/label/error text, option buttons,
+-- dropdown lists), so every form looks consistent instead of each file picking
+-- its own shades. {r, g, b, a} tuples, use with unpack().
+SchlingelInc.Constants.FORM_COLORS = {
+	TITLE               = {1,    0.82, 0,    1},
+	LABEL               = {0.8,  0.8,  0.8,  1},
+	ERROR               = {1,    0.3,  0.3,  1},
+	HOVER               = {1,    1,    0.7,  1},
+	FORM_BG             = {0.07, 0.07, 0.07, 0.98},
+	FORM_BORDER         = {0.45, 0.45, 0.45, 1},
+	EDITBOX_BG          = {0.1,  0.1,  0.1,  0.9},
+	EDITBOX_BORDER      = {0.4,  0.4,  0.4,  1},
+	LIST_BG             = {0.05, 0.05, 0.05, 0.98},
+	LIST_ITEM_TEXT      = {0.85, 0.85, 0.85, 1},
+	OPTION_BG           = {0.18, 0.18, 0.18, 0.9},
+	OPTION_BG_SELECTED  = {0.28, 0.20, 0.0,  1},
+	OPTION_TEXT         = {0.6,  0.6,  0.6,  1},
+}
+
 -- Inactivity threshold (days)
 SchlingelInc.Constants.INACTIVE_DAYS_THRESHOLD = 10
 

--- a/Global.lua
+++ b/Global.lua
@@ -57,14 +57,20 @@ end
 -- ownerFrame (the popup/panel it belongs to) is hidden. listFrame must use a
 -- higher strata than "FULLSCREEN_DIALOG" (e.g. "TOOLTIP", the convention used by
 -- every dropdown list in this addon) so the catcher never swallows item clicks.
-function SchlingelInc:RegisterOutsideClickClose(listFrame, ownerFrame)
+-- excludeFrame (optional) lets clicks on that frame pass through without closing
+-- the list — e.g. an EditBox the list is suggesting against, so clicking it to
+-- keep typing/reposition the cursor doesn't fight with the outside-click catcher.
+function SchlingelInc:RegisterOutsideClickClose(listFrame, ownerFrame, excludeFrame)
     local catcher = CreateFrame("Button", nil, UIParent)
     catcher:SetAllPoints(UIParent)
     catcher:SetFrameStrata("FULLSCREEN_DIALOG")
     catcher:EnableMouse(true)
     catcher:RegisterForClicks("LeftButtonUp", "RightButtonUp")
     catcher:Hide()
-    catcher:SetScript("OnClick", function() listFrame:Hide() end)
+    catcher:SetScript("OnClick", function()
+        if excludeFrame and excludeFrame:IsMouseOver() then return end
+        listFrame:Hide()
+    end)
 
     listFrame:HookScript("OnShow", function() catcher:Show() end)
     listFrame:HookScript("OnHide", function() catcher:Hide() end)
@@ -86,7 +92,7 @@ function SchlingelInc:RegisterDropdownAutoClose(dropdownFrame, onCloseFn)
     catcher:EnableMouse(true)
     catcher:RegisterForClicks("LeftButtonUp", "RightButtonUp")
     catcher:Hide()
-    catcher:SetScript("OnClick", CloseDropDownMenus)
+    catcher:SetScript("OnClick", function() CloseDropDownMenus() end)
 
     DropDownList1:HookScript("OnShow", function()
         if UIDROPDOWNMENU_OPEN_MENU == dropdownFrame then

--- a/Raid.lua
+++ b/Raid.lua
@@ -167,6 +167,33 @@ function SchlingelInc.Raid:Unsignal(id)
     BroadcastUnsignal(id, OwnName())
 end
 
+-- Lets the poster sign someone else up (e.g. a Discord-only signup) or remove any
+-- participant, reusing the same signal protocol as a normal self-signup/withdrawal.
+function SchlingelInc.Raid:AddParticipant(id, name, role)
+    local entry = SchlingelRaidDB.entries[id]
+    if not entry or entry.poster ~= OwnName() then return nil, "Kein eigener Raid-Eintrag." end
+    if not IsEntryActive(entry) then return nil, "Raid nicht (mehr) aktiv." end
+    name = (name or ""):match("^%s*(.-)%s*$")
+    if name == "" then return nil, "Name darf nicht leer sein." end
+    if not IsValidRole(role) then return nil, "Ungültige Rolle." end
+
+    local signal = { role = role, updatedAt = time() }
+    SchlingelRaidDB.signals[id] = SchlingelRaidDB.signals[id] or {}
+    SchlingelRaidDB.signals[id][name] = signal
+    BroadcastSignal(id, signal, name)
+    return true
+end
+
+function SchlingelInc.Raid:RemoveParticipant(id, name)
+    local entry = SchlingelRaidDB.entries[id]
+    if not entry or entry.poster ~= OwnName() then return nil, "Kein eigener Raid-Eintrag." end
+
+    local forId = SchlingelRaidDB.signals[id]
+    if forId then forId[name] = nil end
+    BroadcastUnsignal(id, name)
+    return true
+end
+
 function SchlingelInc.Raid:GetEntry(id)
     return SchlingelRaidDB.entries[id]
 end

--- a/SchlingelInc.toc
+++ b/SchlingelInc.toc
@@ -50,6 +50,7 @@ interfaces\popups\GuildInvites.lua
 interfaces\popups\PvPFrame.lua
 interfaces\popups\RaidPostForm.lua
 interfaces\popups\RaidSignupForm.lua
+interfaces\popups\RaidAddParticipantForm.lua
 interfaces\popups\AchievementAnnouncement.lua
 interfaces\popups\AchievementForm.lua
 interfaces\popups\AchievementGrantForm.lua

--- a/interfaces/GuildPanel/TabRaid.lua
+++ b/interfaces/GuildPanel/TabRaid.lua
@@ -102,9 +102,27 @@ local function CreateCard(parent, cardW, entry)
             for _, s in ipairs(signups) do
                 local rowFs = card:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
                 rowFs:SetPoint("TOPLEFT", card, "TOPLEFT", CARD_PAD, -height)
-                rowFs:SetWidth(cardW - CARD_PAD * 2)
+                rowFs:SetWidth(cardW - CARD_PAD * 2 - (isOwn and 16 or 0))
                 rowFs:SetJustifyH("LEFT")
                 rowFs:SetText(SchlingelInc:SanitizeText(s.name) .. " |cff6699ff(" .. s.role .. ")|r")
+
+                if isOwn then
+                    local removeBtn = CreateFrame("Button", nil, card)
+                    removeBtn:SetSize(14, 14)
+                    removeBtn:SetPoint("TOPRIGHT", card, "TOPRIGHT", -CARD_PAD, -height - 1)
+                    local removeFs = removeBtn:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+                    removeFs:SetAllPoints()
+                    removeFs:SetJustifyH("CENTER")
+                    removeFs:SetText("x")
+                    removeFs:SetTextColor(0.7, 0.3, 0.3, 1)
+                    removeBtn:SetScript("OnClick", function()
+                        SchlingelInc.Raid:RemoveParticipant(entry.id, s.name)
+                        SchlingelInc.GuildPanel:RefreshRaid()
+                    end)
+                    removeBtn:SetScript("OnEnter", function() removeFs:SetTextColor(1, 0.4, 0.4, 1) end)
+                    removeBtn:SetScript("OnLeave", function() removeFs:SetTextColor(0.7, 0.3, 0.3, 1) end)
+                end
+
                 height = height + ROW_H
             end
         end
@@ -146,6 +164,16 @@ local function CreateCard(parent, cardW, entry)
             doneBtn:SetScript("OnClick", function()
                 SchlingelInc.Raid:Cancel(entry.id)
                 SchlingelInc.GuildPanel:RefreshRaid()
+            end)
+
+            height = height + 20 + 6
+
+            local addParticipantBtn = CreateFrame("Button", nil, card, "UIPanelButtonTemplate")
+            addParticipantBtn:SetSize(120, 20)
+            addParticipantBtn:SetPoint("TOPLEFT", card, "TOPLEFT", CARD_PAD, -height)
+            addParticipantBtn:SetText("+ Teilnehmer")
+            addParticipantBtn:SetScript("OnClick", function()
+                SchlingelInc.Popup:ShowRaidAddParticipantForm(entry)
             end)
         end
 

--- a/interfaces/popups/RaidAddParticipantForm.lua
+++ b/interfaces/popups/RaidAddParticipantForm.lua
@@ -9,6 +9,31 @@ local FC = SchlingelInc.Constants.FORM_COLORS
 local FORM_W  = 280
 local INNER_W = FORM_W - 32
 local MAX_SUGGESTIONS = 8
+local MAX_ROLES = #SchlingelInc.Constants.ROLES
+
+-- Roles a given roster member has configured in their guild profile ("Tank/Heal"
+-- style, "/"-delimited), in canonical ROLES order. Empty if no profile or no roles set.
+local function GetProfileRoles(name)
+    local profile = SchlingelGuildProfileCache and SchlingelGuildProfileCache[name]
+    local raw = profile and profile.role or ""
+    local set = {}
+    for part in raw:gmatch("[^/]+") do set[part] = true end
+    local out = {}
+    for _, r in ipairs(SchlingelInc.Constants.ROLES) do
+        if set[r] then table.insert(out, r) end
+    end
+    return out
+end
+
+local function ResolveRosterName(typed)
+    typed = typed:match("^%s*(.-)%s*$")
+    for _, member in ipairs(SchlingelInc.GuildCache:GetFullRoster()) do
+        if member.name:lower() == typed:lower() then
+            return member.name
+        end
+    end
+    return nil
+end
 
 local function CreateEditBox(parent, width, maxLetters)
     local eb = CreateFrame("EditBox", nil, parent, BackdropTemplateMixin and "BackdropTemplate")
@@ -23,6 +48,34 @@ local function CreateEditBox(parent, width, maxLetters)
     eb:SetScript("OnEscapePressed", function(box) box:ClearFocus() end)
     eb:SetScript("OnEnterPressed", function(box) box:ClearFocus() end)
     return eb
+end
+
+-- Shows only the given roles' buttons (in order), keeping the previous selection
+-- if it's still among them, auto-selecting when only one choice remains.
+local function ApplyRoleChoices(f, choices)
+    local previousSelection = f.selectedRole
+    local rbW = math.floor((INNER_W - 4 * (#choices - 1)) / #choices)
+    for i, btn in ipairs(f.roleBtns) do
+        if i <= #choices then
+            btn.roleName = choices[i]
+            btn.lbl:SetText(choices[i])
+            btn:ClearAllPoints()
+            btn:SetSize(rbW, 22)
+            btn:SetPoint("TOPLEFT", f.roleLbl, "BOTTOMLEFT", (i - 1) * (rbW + 4), -4)
+            btn:Show()
+        else
+            btn:Hide()
+        end
+    end
+
+    if #choices == 1 then
+        f.selectedRole = choices[1]
+    else
+        local stillValid = false
+        for _, r in ipairs(choices) do if r == previousSelection then stillValid = true end end
+        f.selectedRole = stillValid and previousSelection or nil
+    end
+    for _, b in ipairs(f.roleBtns) do b.UpdateAppearance() end
 end
 
 local function CreateLabel(parent, text)
@@ -105,13 +158,15 @@ local function BuildForm()
     suggestList:SetBackdropBorderColor(unpack(FC.FORM_BORDER))
     suggestList:SetPoint("TOPLEFT", nameEB, "BOTTOMLEFT", 0, -2)
     suggestList:Hide()
-    -- A full-screen click-catcher (like the other dropdown lists use) would also
-    -- swallow clicks meant for nameEB itself, so close on focus-lost instead —
-    -- delayed slightly so a click on a suggestion button still registers first.
+    -- Outside-click catcher (the same convention every other dropdown list in this
+    -- addon uses) excludes nameEB itself, so clicking back into the box to keep
+    -- typing doesn't fight with it — but Escape/Enter still clear keyboard focus
+    -- without a click, so also close on focus-lost as a fallback, delayed slightly
+    -- so a click on a suggestion button still registers first.
+    SchlingelInc:RegisterOutsideClickClose(suggestList, f, nameEB)
     nameEB:SetScript("OnEditFocusLost", function()
         C_Timer.After(0.15, function() suggestList:Hide() end)
     end)
-    f:HookScript("OnHide", function() suggestList:Hide() end)
 
     local ITEM_H = 18
     local function RefreshSuggestions()
@@ -145,20 +200,18 @@ local function BuildForm()
         suggestList:SetHeight(math.abs(yOff) + 4)
         suggestList:Show()
     end
-    nameEB:SetScript("OnTextChanged", RefreshSuggestions)
-    nameEB:SetScript("OnEditFocusGained", RefreshSuggestions)
-
     -- ── Rolle ────────────────────────────────────────────────────────────────
     local roleLbl = CreateLabel(f, "Rolle:")
     roleLbl:SetPoint("TOPLEFT", nameEB, "BOTTOMLEFT", 0, -14)
+    f.roleLbl = roleLbl
 
+    -- Fixed pool of buttons, sized in ApplyRoleChoices() to whichever subset of
+    -- roles applies to the currently typed name (their profile roles, or the full
+    -- list if unresolved / no profile roles set).
     local roleBtns = {}
-    local roles = SchlingelInc.Constants.ROLES
-    local rbW   = math.floor((INNER_W - 4 * (#roles - 1)) / #roles)
-    for i, roleName in ipairs(roles) do
+    for i = 1, MAX_ROLES do
         local btn = CreateFrame("Button", nil, f)
-        btn:SetSize(rbW, 22)
-        btn:SetPoint("TOPLEFT", roleLbl, "BOTTOMLEFT", (i - 1) * (rbW + 4), -4)
+        btn:SetSize(10, 22)
         btn:EnableMouse(true)
 
         local bg = btn:CreateTexture(nil, "BACKGROUND")
@@ -168,10 +221,10 @@ local function BuildForm()
         local lbl = btn:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
         lbl:SetAllPoints()
         lbl:SetJustifyH("CENTER")
-        lbl:SetText(roleName)
+        btn.lbl = lbl
 
         local function UpdateBtn()
-            if f.selectedRole == roleName then
+            if f.selectedRole == btn.roleName then
                 bg:SetColorTexture(unpack(FC.OPTION_BG_SELECTED))
                 lbl:SetTextColor(unpack(FC.TITLE))
             else
@@ -180,10 +233,9 @@ local function BuildForm()
             end
         end
         btn.UpdateAppearance = UpdateBtn
-        UpdateBtn()
 
         btn:SetScript("OnClick", function()
-            f.selectedRole = roleName
+            f.selectedRole = btn.roleName
             for _, b in ipairs(roleBtns) do b.UpdateAppearance() end
         end)
         btn:SetScript("OnEnter", function() lbl:SetTextColor(unpack(FC.HOVER)) end)
@@ -192,6 +244,21 @@ local function BuildForm()
         roleBtns[i] = btn
     end
     f.roleBtns = roleBtns
+
+    local function RefreshRoleChoices()
+        local resolvedName = ResolveRosterName(nameEB:GetText())
+        local choices = resolvedName and GetProfileRoles(resolvedName) or {}
+        if #choices == 0 then
+            choices = { unpack(SchlingelInc.Constants.ROLES) }
+        end
+        ApplyRoleChoices(f, choices)
+    end
+
+    nameEB:SetScript("OnTextChanged", function()
+        RefreshSuggestions()
+        RefreshRoleChoices()
+    end)
+    nameEB:SetScript("OnEditFocusGained", RefreshSuggestions)
 
     local errorFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     errorFs:SetPoint("TOPLEFT", roleLbl, "BOTTOMLEFT", 0, -34)
@@ -214,14 +281,7 @@ local function BuildForm()
     addBtn:SetScript("OnClick", function()
         errorFs:SetText("")
 
-        local typed = nameEB:GetText():match("^%s*(.-)%s*$")
-        local resolvedName = nil
-        for _, member in ipairs(SchlingelInc.GuildCache:GetFullRoster()) do
-            if member.name:lower() == typed:lower() then
-                resolvedName = member.name
-                break
-            end
-        end
+        local resolvedName = ResolveRosterName(nameEB:GetText())
         if not resolvedName then
             errorFs:SetText("Bitte einen gültigen Namen aus der Gilde auswählen.")
             return

--- a/interfaces/popups/RaidAddParticipantForm.lua
+++ b/interfaces/popups/RaidAddParticipantForm.lua
@@ -1,0 +1,265 @@
+-- interfaces/popups/RaidAddParticipantForm.lua
+-- Poster-only popup to add (or correct) a raid participant who signed up outside
+-- the addon, e.g. in Discord. Name must resolve to an actual guild member.
+
+SchlingelInc.Popup = SchlingelInc.Popup or {}
+
+local FC = SchlingelInc.Constants.FORM_COLORS
+
+local FORM_W  = 280
+local INNER_W = FORM_W - 32
+local MAX_SUGGESTIONS = 8
+
+local function CreateEditBox(parent, width, maxLetters)
+    local eb = CreateFrame("EditBox", nil, parent, BackdropTemplateMixin and "BackdropTemplate")
+    eb:SetSize(width, 22)
+    eb:SetBackdrop(SchlingelInc.Constants.POPUPBACKDROP)
+    eb:SetBackdropColor(unpack(FC.EDITBOX_BG))
+    eb:SetBackdropBorderColor(unpack(FC.EDITBOX_BORDER))
+    eb:SetFontObject("GameFontHighlight")
+    eb:SetTextInsets(6, 6, 0, 0)
+    eb:SetAutoFocus(false)
+    eb:SetMaxLetters(maxLetters)
+    eb:SetScript("OnEscapePressed", function(box) box:ClearFocus() end)
+    eb:SetScript("OnEnterPressed", function(box) box:ClearFocus() end)
+    return eb
+end
+
+local function CreateLabel(parent, text)
+    local lbl = parent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    lbl:SetText(text)
+    lbl:SetTextColor(unpack(FC.LABEL))
+    return lbl
+end
+
+-- Matches roster members by character name OR by the Discord handle stored in their
+-- profile — a Discord signup names the person, not necessarily this specific
+-- character, so one query can surface several of that player's guild characters.
+local function MatchingRosterNames(query)
+    query = query:lower()
+    if query == "" then return {} end
+
+    local out = {}
+    for _, member in ipairs(SchlingelInc.GuildCache:GetFullRoster()) do
+        local nameMatches = member.name:lower():find(query, 1, true)
+        local profile = SchlingelGuildProfileCache and SchlingelGuildProfileCache[member.name]
+        local discord = profile and profile.discord or ""
+        local discordMatches = not nameMatches and discord ~= "" and discord:lower():find(query, 1, true)
+        if nameMatches or discordMatches then
+            table.insert(out, { name = member.name, discord = discordMatches and discord or nil })
+            if #out >= MAX_SUGGESTIONS then break end
+        end
+    end
+    table.sort(out, function(a, b) return a.name < b.name end)
+    return out
+end
+
+local function BuildForm()
+    local f = CreateFrame("Frame", "SchlingelRaidAddParticipantForm", UIParent, "BackdropTemplate")
+    f:SetSize(FORM_W, 230)
+    f:SetFrameStrata("DIALOG")
+    f:SetBackdrop(SchlingelInc.Constants.BACKDROP)
+    f:SetBackdropColor(unpack(FC.FORM_BG))
+    f:SetBackdropBorderColor(unpack(FC.FORM_BORDER))
+    f:SetMovable(true)
+    f:EnableMouse(true)
+    f:RegisterForDrag("LeftButton")
+    f:SetScript("OnDragStart", f.StartMoving)
+    f:SetScript("OnDragStop", function(self)
+        self:StopMovingOrSizing()
+        SchlingelInc:SaveFramePosition(self, "raidaddparticipantform_position")
+    end)
+    SchlingelInc:RestoreFramePosition(f, "raidaddparticipantform_position", "CENTER", 0, 40)
+    SchlingelInc:RegisterFrameForEscape(f)
+    f:Hide()
+
+    local titleFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+    titleFs:SetPoint("TOP", f, "TOP", 0, -16)
+    titleFs:SetText("Teilnehmer hinzufügen")
+    titleFs:SetTextColor(unpack(FC.TITLE))
+
+    local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
+    closeBtn:SetSize(20, 20)
+    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -2, -2)
+    closeBtn:SetScript("OnClick", function() f:Hide() end)
+
+    local raidFs = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    raidFs:SetPoint("TOP", titleFs, "BOTTOM", 0, -6)
+    raidFs:SetWidth(INNER_W)
+    raidFs:SetJustifyH("CENTER")
+    f.raidFs = raidFs
+
+    -- ── Name (autocomplete against Charaktername + Discord-Handle) ──────────
+    local nameLbl = CreateLabel(f, "Name oder Discord:")
+    nameLbl:SetPoint("TOPLEFT", f, "TOPLEFT", 16, -66)
+
+    local nameEB = CreateEditBox(f, INNER_W, 24)
+    nameEB:SetPoint("TOPLEFT", nameLbl, "BOTTOMLEFT", 0, -4)
+    f.nameEB = nameEB
+
+    local suggestList = CreateFrame("Frame", "SchlingelRaidAddParticipantSuggestions", UIParent, "BackdropTemplate")
+    suggestList:SetSize(INNER_W, 10)
+    suggestList:SetFrameStrata("TOOLTIP")
+    suggestList:SetBackdrop(SchlingelInc.Constants.DROPDOWNBACKDROP)
+    suggestList:SetBackdropColor(unpack(FC.LIST_BG))
+    suggestList:SetBackdropBorderColor(unpack(FC.FORM_BORDER))
+    suggestList:SetPoint("TOPLEFT", nameEB, "BOTTOMLEFT", 0, -2)
+    suggestList:Hide()
+    -- A full-screen click-catcher (like the other dropdown lists use) would also
+    -- swallow clicks meant for nameEB itself, so close on focus-lost instead —
+    -- delayed slightly so a click on a suggestion button still registers first.
+    nameEB:SetScript("OnEditFocusLost", function()
+        C_Timer.After(0.15, function() suggestList:Hide() end)
+    end)
+    f:HookScript("OnHide", function() suggestList:Hide() end)
+
+    local ITEM_H = 18
+    local function RefreshSuggestions()
+        for _, child in ipairs({ suggestList:GetChildren() }) do child:Hide() end
+
+        local matches = MatchingRosterNames(nameEB:GetText())
+        if #matches == 0 then
+            suggestList:Hide()
+            return
+        end
+
+        local yOff = -4
+        for _, match in ipairs(matches) do
+            local btn = CreateFrame("Button", nil, suggestList)
+            btn:SetSize(INNER_W - 8, ITEM_H)
+            btn:SetPoint("TOPLEFT", suggestList, "TOPLEFT", 4, yOff)
+            local lbl = btn:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+            lbl:SetAllPoints()
+            lbl:SetJustifyH("LEFT")
+            lbl:SetText(match.discord and (match.name .. " |cff888888(" .. match.discord .. ")|r") or match.name)
+            lbl:SetTextColor(unpack(FC.LIST_ITEM_TEXT))
+            btn:SetScript("OnClick", function()
+                nameEB:SetText(match.name)
+                nameEB:ClearFocus()
+                suggestList:Hide()
+            end)
+            btn:SetScript("OnEnter", function() lbl:SetTextColor(unpack(FC.HOVER)) end)
+            btn:SetScript("OnLeave", function() lbl:SetTextColor(unpack(FC.LIST_ITEM_TEXT)) end)
+            yOff = yOff - ITEM_H - 2
+        end
+        suggestList:SetHeight(math.abs(yOff) + 4)
+        suggestList:Show()
+    end
+    nameEB:SetScript("OnTextChanged", RefreshSuggestions)
+    nameEB:SetScript("OnEditFocusGained", RefreshSuggestions)
+
+    -- ── Rolle ────────────────────────────────────────────────────────────────
+    local roleLbl = CreateLabel(f, "Rolle:")
+    roleLbl:SetPoint("TOPLEFT", nameEB, "BOTTOMLEFT", 0, -14)
+
+    local roleBtns = {}
+    local roles = SchlingelInc.Constants.ROLES
+    local rbW   = math.floor((INNER_W - 4 * (#roles - 1)) / #roles)
+    for i, roleName in ipairs(roles) do
+        local btn = CreateFrame("Button", nil, f)
+        btn:SetSize(rbW, 22)
+        btn:SetPoint("TOPLEFT", roleLbl, "BOTTOMLEFT", (i - 1) * (rbW + 4), -4)
+        btn:EnableMouse(true)
+
+        local bg = btn:CreateTexture(nil, "BACKGROUND")
+        bg:SetAllPoints()
+        bg:SetColorTexture(unpack(FC.OPTION_BG))
+
+        local lbl = btn:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+        lbl:SetAllPoints()
+        lbl:SetJustifyH("CENTER")
+        lbl:SetText(roleName)
+
+        local function UpdateBtn()
+            if f.selectedRole == roleName then
+                bg:SetColorTexture(unpack(FC.OPTION_BG_SELECTED))
+                lbl:SetTextColor(unpack(FC.TITLE))
+            else
+                bg:SetColorTexture(unpack(FC.OPTION_BG))
+                lbl:SetTextColor(unpack(FC.OPTION_TEXT))
+            end
+        end
+        btn.UpdateAppearance = UpdateBtn
+        UpdateBtn()
+
+        btn:SetScript("OnClick", function()
+            f.selectedRole = roleName
+            for _, b in ipairs(roleBtns) do b.UpdateAppearance() end
+        end)
+        btn:SetScript("OnEnter", function() lbl:SetTextColor(unpack(FC.HOVER)) end)
+        btn:SetScript("OnLeave", UpdateBtn)
+
+        roleBtns[i] = btn
+    end
+    f.roleBtns = roleBtns
+
+    local errorFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    errorFs:SetPoint("TOPLEFT", roleLbl, "BOTTOMLEFT", 0, -34)
+    errorFs:SetWidth(INNER_W)
+    errorFs:SetJustifyH("LEFT")
+    errorFs:SetTextColor(unpack(FC.ERROR))
+    f.errorFs = errorFs
+
+    local addBtn = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+    addBtn:SetSize(100, 22)
+    addBtn:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -16, 16)
+    addBtn:SetText("Hinzufügen")
+
+    local cancelBtn = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+    cancelBtn:SetSize(90, 22)
+    cancelBtn:SetPoint("RIGHT", addBtn, "LEFT", -8, 0)
+    cancelBtn:SetText("Abbrechen")
+    cancelBtn:SetScript("OnClick", function() f:Hide() end)
+
+    addBtn:SetScript("OnClick", function()
+        errorFs:SetText("")
+
+        local typed = nameEB:GetText():match("^%s*(.-)%s*$")
+        local resolvedName = nil
+        for _, member in ipairs(SchlingelInc.GuildCache:GetFullRoster()) do
+            if member.name:lower() == typed:lower() then
+                resolvedName = member.name
+                break
+            end
+        end
+        if not resolvedName then
+            errorFs:SetText("Bitte einen gültigen Namen aus der Gilde auswählen.")
+            return
+        end
+        if not f.selectedRole then
+            errorFs:SetText("Bitte eine Rolle auswählen.")
+            return
+        end
+
+        local ok, err = SchlingelInc.Raid:AddParticipant(f.entryId, resolvedName, f.selectedRole)
+        if not ok then
+            errorFs:SetText(err or "Unbekannter Fehler.")
+            return
+        end
+
+        f:Hide()
+        if SchlingelInc.GuildPanel and SchlingelInc.GuildPanel.RefreshRaid then
+            SchlingelInc.GuildPanel:RefreshRaid()
+        end
+    end)
+
+    f.titleFs = titleFs
+    return f
+end
+
+function SchlingelInc.Popup:ShowRaidAddParticipantForm(entry)
+    if not entry then return end
+    if not SchlingelInc.Popup.raidAddParticipantForm then
+        SchlingelInc.Popup.raidAddParticipantForm = BuildForm()
+    end
+    local f = SchlingelInc.Popup.raidAddParticipantForm
+
+    f.entryId = entry.id
+    f.raidFs:SetText(SchlingelInc:SanitizeText(entry.title))
+    f.errorFs:SetText("")
+    f.nameEB:SetText("")
+    f.selectedRole = nil
+    for _, b in ipairs(f.roleBtns) do b.UpdateAppearance() end
+
+    f:Show()
+end

--- a/interfaces/popups/RaidPostForm.lua
+++ b/interfaces/popups/RaidPostForm.lua
@@ -3,6 +3,8 @@
 
 SchlingelInc.Popup = SchlingelInc.Popup or {}
 
+local FC = SchlingelInc.Constants.FORM_COLORS
+
 local FORM_W  = 460
 local INNER_W = FORM_W - 32
 
@@ -10,8 +12,8 @@ local function CreateEditBox(parent, width, maxLetters, numeric)
     local eb = CreateFrame("EditBox", nil, parent, BackdropTemplateMixin and "BackdropTemplate")
     eb:SetSize(width, 22)
     eb:SetBackdrop(SchlingelInc.Constants.POPUPBACKDROP)
-    eb:SetBackdropColor(0.1, 0.1, 0.1, 0.9)
-    eb:SetBackdropBorderColor(0.4, 0.4, 0.4, 1)
+    eb:SetBackdropColor(unpack(FC.EDITBOX_BG))
+    eb:SetBackdropBorderColor(unpack(FC.EDITBOX_BORDER))
     eb:SetFontObject("GameFontHighlight")
     eb:SetTextInsets(6, 6, 0, 0)
     eb:SetAutoFocus(false)
@@ -25,7 +27,7 @@ end
 local function CreateLabel(parent, text)
     local lbl = parent:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     lbl:SetText(text)
-    lbl:SetTextColor(0.8, 0.8, 0.8, 1)
+    lbl:SetTextColor(unpack(FC.LABEL))
     return lbl
 end
 
@@ -34,8 +36,8 @@ local function BuildForm()
     f:SetSize(FORM_W, 380)
     f:SetFrameStrata("DIALOG")
     f:SetBackdrop(SchlingelInc.Constants.BACKDROP)
-    f:SetBackdropColor(0.07, 0.07, 0.07, 0.98)
-    f:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
+    f:SetBackdropColor(unpack(FC.FORM_BG))
+    f:SetBackdropBorderColor(unpack(FC.FORM_BORDER))
     f:SetMovable(true)
     f:EnableMouse(true)
     f:RegisterForDrag("LeftButton")
@@ -50,7 +52,7 @@ local function BuildForm()
 
     local titleFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
     titleFs:SetPoint("TOP", f, "TOP", 0, -16)
-    titleFs:SetTextColor(1, 0.82, 0, 1)
+    titleFs:SetTextColor(unpack(FC.TITLE))
     f.titleFs = titleFs
 
     local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
@@ -82,14 +84,9 @@ local function BuildForm()
     local instList = CreateFrame("Frame", "SchlingelRaidPostFormInstList", UIParent, "BackdropTemplate")
     instList:SetSize(INNER_W, 10)
     instList:SetFrameStrata("TOOLTIP")
-    instList:SetBackdrop({
-        bgFile   = "Interface\\BUTTONS\\WHITE8X8",
-        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-        tile = true, tileSize = 16, edgeSize = 16,
-        insets = { left = 4, right = 4, top = 4, bottom = 4 }
-    })
-    instList:SetBackdropColor(0.05, 0.05, 0.05, 0.98)
-    instList:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
+    instList:SetBackdrop(SchlingelInc.Constants.DROPDOWNBACKDROP)
+    instList:SetBackdropColor(unpack(FC.LIST_BG))
+    instList:SetBackdropBorderColor(unpack(FC.FORM_BORDER))
     instList:SetPoint("TOPLEFT", instBtn, "BOTTOMLEFT", 0, -2)
     instList:Hide()
     f.instList = instList
@@ -106,14 +103,14 @@ local function BuildForm()
         lbl:SetJustifyH("LEFT")
         lbl:SetWordWrap(false)
         lbl:SetText(name)
-        lbl:SetTextColor(0.85, 0.85, 0.85, 1)
+        lbl:SetTextColor(unpack(FC.LIST_ITEM_TEXT))
         btn:SetScript("OnClick", function()
             f.selectedInstance = name
             instBtn:SetText(name)
             instList:Hide()
         end)
-        btn:SetScript("OnEnter", function() lbl:SetTextColor(1, 1, 0.7, 1) end)
-        btn:SetScript("OnLeave", function() lbl:SetTextColor(0.85, 0.85, 0.85, 1) end)
+        btn:SetScript("OnEnter", function() lbl:SetTextColor(unpack(FC.HOVER)) end)
+        btn:SetScript("OnLeave", function() lbl:SetTextColor(unpack(FC.LIST_ITEM_TEXT)) end)
         yOff = yOff - ITEM_H - 2
     end
     instList:SetHeight(math.abs(yOff) + 4)
@@ -166,7 +163,7 @@ local function BuildForm()
     errorFs:SetPoint("TOPLEFT", noteEB, "BOTTOMLEFT", 0, -12)
     errorFs:SetWidth(INNER_W)
     errorFs:SetJustifyH("LEFT")
-    errorFs:SetTextColor(1, 0.3, 0.3, 1)
+    errorFs:SetTextColor(unpack(FC.ERROR))
     f.errorFs = errorFs
 
     local submitBtn = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")

--- a/interfaces/popups/RaidSignupForm.lua
+++ b/interfaces/popups/RaidSignupForm.lua
@@ -6,6 +6,8 @@
 
 SchlingelInc.Popup = SchlingelInc.Popup or {}
 
+local FC = SchlingelInc.Constants.FORM_COLORS
+
 local FORM_W    = 260
 local INNER_W   = FORM_W - 32
 local MAX_ROLES = #SchlingelInc.Constants.ROLES
@@ -26,8 +28,8 @@ local function BuildForm()
     f:SetSize(FORM_W, 150)
     f:SetFrameStrata("DIALOG")
     f:SetBackdrop(SchlingelInc.Constants.BACKDROP)
-    f:SetBackdropColor(0.07, 0.07, 0.07, 0.98)
-    f:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
+    f:SetBackdropColor(unpack(FC.FORM_BG))
+    f:SetBackdropBorderColor(unpack(FC.FORM_BORDER))
     f:SetMovable(true)
     f:EnableMouse(true)
     f:RegisterForDrag("LeftButton")
@@ -43,7 +45,7 @@ local function BuildForm()
     local titleFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
     titleFs:SetPoint("TOP", f, "TOP", 0, -16)
     titleFs:SetText("Zusagen")
-    titleFs:SetTextColor(1, 0.82, 0, 1)
+    titleFs:SetTextColor(unpack(FC.TITLE))
 
     local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
     closeBtn:SetSize(20, 20)
@@ -60,7 +62,7 @@ local function BuildForm()
     local roleLbl = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     roleLbl:SetPoint("TOPLEFT", f, "TOPLEFT", 16, -68)
     roleLbl:SetText("Rolle:")
-    roleLbl:SetTextColor(0.8, 0.8, 0.8, 1)
+    roleLbl:SetTextColor(unpack(FC.LABEL))
 
     local soloFs = f:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     soloFs:SetPoint("TOPLEFT", roleLbl, "BOTTOMLEFT", 2, -6)
@@ -74,7 +76,7 @@ local function BuildForm()
 
         local bg = btn:CreateTexture(nil, "BACKGROUND")
         bg:SetAllPoints()
-        bg:SetColorTexture(0.18, 0.18, 0.18, 0.9)
+        bg:SetColorTexture(unpack(FC.OPTION_BG))
 
         local lbl = btn:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
         lbl:SetAllPoints()
@@ -83,11 +85,11 @@ local function BuildForm()
 
         local function UpdateBtn()
             if f.selectedRole == btn.roleName then
-                bg:SetColorTexture(0.28, 0.20, 0.0, 1)
-                lbl:SetTextColor(1, 0.82, 0, 1)
+                bg:SetColorTexture(unpack(FC.OPTION_BG_SELECTED))
+                lbl:SetTextColor(unpack(FC.TITLE))
             else
-                bg:SetColorTexture(0.18, 0.18, 0.18, 0.9)
-                lbl:SetTextColor(0.6, 0.6, 0.6, 1)
+                bg:SetColorTexture(unpack(FC.OPTION_BG))
+                lbl:SetTextColor(unpack(FC.OPTION_TEXT))
             end
         end
         btn.UpdateAppearance = UpdateBtn
@@ -96,7 +98,7 @@ local function BuildForm()
             f.selectedRole = btn.roleName
             for _, b in ipairs(roleBtns) do b.UpdateAppearance() end
         end)
-        btn:SetScript("OnEnter", function() lbl:SetTextColor(1, 1, 0.7, 1) end)
+        btn:SetScript("OnEnter", function() lbl:SetTextColor(unpack(FC.HOVER)) end)
         btn:SetScript("OnLeave", UpdateBtn)
 
         roleBtns[i] = btn
@@ -108,7 +110,7 @@ local function BuildForm()
     errorFs:SetPoint("TOPLEFT", roleLbl, "BOTTOMLEFT", 0, -34)
     errorFs:SetWidth(INNER_W)
     errorFs:SetJustifyH("LEFT")
-    errorFs:SetTextColor(1, 0.3, 0.3, 1)
+    errorFs:SetTextColor(unpack(FC.ERROR))
     f.errorFs = errorFs
 
     local confirmBtn = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")


### PR DESCRIPTION
## Summary
- Poster können Raid-Teilnehmende manuell hinzufügen (Namensauswahl per Autocomplete gegen Roster + Discord-Handle) oder entfernen
- Rollenauswahl beim Hinzufügen zeigt nur die im Gildenprofil hinterlegten Rollen der ausgewählten Person, statt immer Tank/Heal/DPS offen zu lassen
- Namens-Vorschlagsliste schließt jetzt auch bei Klick außerhalb (nicht nur bei Fokusverlust)
- Crash-Fix: `CloseDropDownMenus` war direkt als OnClick-Handler registriert und bekam dadurch den Klick-Catcher-Frame als `level`-Parameter übergeben, was im Mitglieder-Kontextmenü im Officer Panel zum Absturz führte