### PR TITLE
Erfolge-Sync: Broadcast-Storm beheben, Katalog-Aktualisierung manuell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Raid-Modul in optionales Sub-Addon SchlingelInc_Raid ausgelagert
 - Raid-Sync: Jittered Reply + Suppression statt Broadcast-Storm, Signup-Batching, Relay direkt über CTL
+- Erfolge-Sync: Jittered Reply + Suppression statt Broadcast-Storm, Relay direkt über CTL, Katalog-Aktualisierung jetzt manuell per Button
+- Erfolge: doppelten Code in Verleihen/Entziehen-Popups zusammengeführt, ungesicherte Tooltip-Abfrage abgesichert
 
 # 4.2.6
 

--- a/SchlingelInc.toc
+++ b/SchlingelInc.toc
@@ -49,6 +49,7 @@ interfaces\popups\GuildInvites.lua
 interfaces\popups\PvPFrame.lua
 interfaces\popups\AchievementAnnouncement.lua
 interfaces\popups\AchievementForm.lua
+interfaces\popups\AchievementActionForm.lua
 interfaces\popups\AchievementGrantForm.lua
 interfaces\popups\AchievementRevokeForm.lua
 interfaces\PopupEditMode.lua

--- a/Tooltip.lua
+++ b/Tooltip.lua
@@ -52,7 +52,7 @@ _G.GameTooltip:HookScript("OnTooltipSetUnit", function(self)
 
     -- Achievement rank + Schlingelpunkte
     if profile.achievementScore and profile.achievementScore > 0 then
-        local rank = SchlingelInc.Achievements.Progress:GetRankForScore(profile.achievementScore)
+        local rank = SchlingelInc.Achievements and SchlingelInc.Achievements.Progress:GetRankForScore(profile.achievementScore)
         if rank then
             _G.GameTooltip:AddDoubleLine("Rang:", rank.name, 1, 0.82, 0, 1, 0.82, 0)
         end

--- a/achievements/Catalog.lua
+++ b/achievements/Catalog.lua
@@ -91,7 +91,7 @@ function Catalog:Create(kind, name, description, points, critA, critB, isGlobal)
     if name == "" then return nil, "Name darf nicht leer sein." end
     points = tonumber(points)
     if not points or points < 0 then return nil, "Ungültige Punktzahl." end
-    isGlobal = isGlobal == true or isGlobal == 1 or isGlobal == "1"
+    isGlobal = SchlingelInc.Achievements.IsTruthyFlag(isGlobal)
 
     local id = OwnName() .. "-" .. time()
     local entry = {
@@ -122,7 +122,7 @@ function Catalog:Edit(id, name, description, points, critA, critB, isGlobal)
     if name == "" then return nil, "Name darf nicht leer sein." end
     points = tonumber(points)
     if not points or points < 0 then return nil, "Ungültige Punktzahl." end
-    isGlobal = isGlobal == true or isGlobal == 1 or isGlobal == "1"
+    isGlobal = SchlingelInc.Achievements.IsTruthyFlag(isGlobal)
 
     entry.name        = SanitizeForMessage(name):sub(1, NAME_MAX_LEN)
     entry.description = SanitizeForMessage(description or ""):sub(1, DESC_MAX_LEN)
@@ -162,7 +162,7 @@ function Catalog:GetAll()
     return out
 end
 
--- Non-retired entries only (member view + detectors).
+-- Non-retired entries only (member view).
 function Catalog:GetActive()
     local out = {}
     for _, entry in pairs(SchlingelAchievementDB.entries) do
@@ -170,6 +170,14 @@ function Catalog:GetActive()
     end
     SortEntries(out)
     return out
+end
+
+-- Unsorted scan over non-retired entries, for detectors (KillDetector/LevelDetector)
+-- that only need to test each entry, not display them in order.
+function Catalog:ForEachActive(fn)
+    for _, entry in pairs(SchlingelAchievementDB.entries) do
+        if not entry.retired then fn(entry) end
+    end
 end
 
 function Catalog:RequestSync()

--- a/achievements/Catalog.lua
+++ b/achievements/Catalog.lua
@@ -1,7 +1,7 @@
 -- Achievements/Catalog.lua
--- Officer-authored achievement definitions (the catalog), broadcast to the guild and
--- kept in sync the same way Raid.lua syncs its entries: the creator re-broadcasts
--- their own entries on login, and answers sync requests from anyone who missed one.
+-- Officer-authored achievement definitions (the catalog), broadcast to the guild.
+-- Sync is manual (RequestSync, triggered by the refresh button): any online peer
+-- relays what it knows, jittered and suppressed the same way Raid.lua does.
 
 local KIND = SchlingelInc.Achievements.KIND
 
@@ -46,16 +46,37 @@ local function IsValidKind(kind)
     return kind == KIND.LEVEL or kind == KIND.KILL_COUNT or kind == KIND.MANUAL
 end
 
+local function RandomDelay(minSeconds, maxSeconds)
+    return minSeconds + math.random() * (maxSeconds - minSeconds)
+end
+
+local RELAY_JITTER_MIN = 0.5
+local RELAY_JITTER_MAX = 3.0
+
+local pendingRelay  = {}
+local answeredSince = {}
+
 -- ── Broadcast ────────────────────────────────────────────────────────────────────
 
-local function BroadcastDefine(entry)
+-- Bypasses SchlingelInc:SendAddonMessage's direct-send attempt, which races the
+-- same client-wide throttle every other module's messages use. Relay traffic is
+-- bursty enough that it should always go straight through CTL instead.
+local function SendRelayMessage(payload)
+    ChatThrottleLib:SendAddonMessage("BULK", SchlingelInc.prefix, payload, "GUILD", nil, "SchlingelInc-AchievementsRelay")
+end
+
+local function BroadcastDefine(entry, isRelay)
     local payload = table.concat({
         MSG_DEFINE, entry.id, entry.kind,
         SanitizeForMessage(entry.name), SanitizeForMessage(entry.description),
         tostring(entry.points), tostring(entry.critA or ""), tostring(entry.critB or ""),
-        entry.retired and "1" or "0", (entry.isGlobal and "1" or "0"),
+        entry.retired and "1" or "0", (entry.isGlobal and "1" or "0"), tostring(entry.updatedAt or time()),
     }, "|")
-    SchlingelInc:SendAddonMessage("NORMAL", payload, "GUILD", nil, "SchlingelInc-Achievements")
+    if isRelay then
+        SendRelayMessage(payload)
+    else
+        SchlingelInc:SendAddonMessage("NORMAL", payload, "GUILD", nil, "SchlingelInc-Achievements")
+    end
 end
 
 -- ── Public API (officer actions) ──────────────────────────────────────────────────
@@ -156,15 +177,27 @@ function Catalog:RequestSync()
     SchlingelInc:SendAddonMessage("NORMAL", MSG_SYNC_REQUEST, "GUILD", nil, "SchlingelInc-Achievements")
 end
 
--- Re-broadcasts every entry this character created, so a login catches up anyone
--- who missed the original broadcast. Mirrors Raid.lua's BroadcastOwnState.
-local function BroadcastOwnState()
+local function RelayEntry(id)
+    local entry = SchlingelAchievementDB.entries[id]
+    if not entry then return end
+    BroadcastDefine(entry, true)
+end
+
+local function ScheduleRelay(id)
+    if pendingRelay[id] then return end
+    pendingRelay[id] = true
+    local requestedAt = time()
+    C_Timer.After(RandomDelay(RELAY_JITTER_MIN, RELAY_JITTER_MAX), function()
+        pendingRelay[id] = nil
+        if (answeredSince[id] or 0) >= requestedAt then return end
+        RelayEntry(id)
+    end)
+end
+
+local function HandleSyncRequest()
     if not IsInGuild() then return end
-    local own = OwnName()
-    for _, entry in pairs(SchlingelAchievementDB.entries) do
-        if entry.createdBy == own then
-            BroadcastDefine(entry)
-        end
+    for id in pairs(SchlingelAchievementDB.entries) do
+        ScheduleRelay(id)
     end
 end
 
@@ -172,12 +205,16 @@ end
 
 function Catalog:HandleMessage(message, sender)
     if message == MSG_SYNC_REQUEST then
-        BroadcastOwnState()
+        HandleSyncRequest()
         return true
     end
 
-    local id, kind, name, description, pointsStr, critAStr, critBStr, retiredStr, isGlobalStr =
-        message:match("^" .. MSG_DEFINE .. "|([^|]+)|([^|]+)|([^|]*)|([^|]*)|(%d+)|([^|]*)|([^|]*)|([01])|([01])$")
+    local id, kind, name, description, pointsStr, critAStr, critBStr, retiredStr, isGlobalStr, updatedAtStr =
+        message:match("^" .. MSG_DEFINE .. "|([^|]+)|([^|]+)|([^|]*)|([^|]*)|(%d+)|([^|]*)|([^|]*)|([01])|([01])|(%d+)$")
+    if not id then
+        id, kind, name, description, pointsStr, critAStr, critBStr, retiredStr, isGlobalStr =
+            message:match("^" .. MSG_DEFINE .. "|([^|]+)|([^|]+)|([^|]*)|([^|]*)|(%d+)|([^|]*)|([^|]*)|([01])|([01])$")
+    end
     if not id then
         id, kind, name, description, pointsStr, critAStr, critBStr, retiredStr =
             message:match("^" .. MSG_DEFINE .. "|([^|]+)|([^|]+)|([^|]*)|([^|]*)|(%d+)|([^|]*)|([^|]*)|([01])$")
@@ -191,6 +228,12 @@ function Catalog:HandleMessage(message, sender)
         local senderShort = SchlingelInc:RemoveRealmFromName(sender)
         if idCreator ~= senderShort then return true end
         if existing and existing.createdBy ~= senderShort then return true end
+        answeredSince[id] = time()
+
+        local incomingUpdatedAt = tonumber(updatedAtStr) or 0
+        if existing and existing.updatedAt and existing.updatedAt >= incomingUpdatedAt then
+            return true
+        end
 
         SchlingelAchievementDB.entries[id] = {
             id          = id,
@@ -202,7 +245,7 @@ function Catalog:HandleMessage(message, sender)
             critB       = critBStr ~= "" and (tonumber(critBStr) or critBStr) or nil,
             createdBy   = senderShort,
             createdAt   = (existing and existing.createdAt) or time(),
-            updatedAt   = time(),
+            updatedAt   = incomingUpdatedAt,
             retired     = retiredStr == "1",
             isGlobal    = isGlobalStr == "1",
         }
@@ -227,14 +270,4 @@ function Catalog:Initialize()
             if prefix ~= SchlingelInc.prefix then return end
             Catalog:HandleMessage(message, sender)
         end, 0, "AchievementCatalogAddonMessage")
-
-    SchlingelInc.EventManager:RegisterHandler("PLAYER_ENTERING_WORLD",
-        function()
-            C_Timer.After(6, function()
-                if IsInGuild() then
-                    BroadcastOwnState()
-                    Catalog:RequestSync()
-                end
-            end)
-        end, 0, "AchievementCatalogBroadcastAndSync")
 end

--- a/achievements/KillDetector.lua
+++ b/achievements/KillDetector.lua
@@ -21,7 +21,7 @@ function KillDetector:HandleCombatLogEvent()
     if not npcID then return end
 
     local Progress = SchlingelInc.Achievements.Progress
-    for _, entry in ipairs(SchlingelInc.Achievements.Catalog:GetActive()) do
+    SchlingelInc.Achievements.Catalog:ForEachActive(function(entry)
         if entry.kind == KIND.KILL_COUNT and tonumber(entry.critA) == npcID
                 and not Progress:IsUnlocked(entry.id) then
             local required = tonumber(entry.critB) or 0
@@ -30,7 +30,7 @@ function KillDetector:HandleCombatLogEvent()
                 Progress:Unlock(entry.id)
             end
         end
-    end
+    end)
 end
 
 function KillDetector:Initialize()

--- a/achievements/LevelDetector.lua
+++ b/achievements/LevelDetector.lua
@@ -16,15 +16,15 @@ function LevelDetector:Check()
     local level = UnitLevel("player")
     local Progress = SchlingelInc.Achievements.Progress
 
-    for _, entry in ipairs(SchlingelInc.Achievements.Catalog:GetActive()) do
+    SchlingelInc.Achievements.Catalog:ForEachActive(function(entry)
         if entry.kind == KIND.LEVEL and not Progress:IsUnlocked(entry.id) then
             local threshold      = tonumber(entry.critA)
-            local requireNoDeath = entry.critB == true or entry.critB == 1 or entry.critB == "1"
+            local requireNoDeath = SchlingelInc.Achievements.IsTruthyFlag(entry.critB)
             if threshold and level >= threshold and (not requireNoDeath or (CharacterDeaths or 0) == 0) then
                 Progress:Unlock(entry.id)
             end
         end
-    end
+    end)
 end
 
 function LevelDetector:Initialize()

--- a/achievements/ManualGrant.lua
+++ b/achievements/ManualGrant.lua
@@ -6,8 +6,6 @@
 -- progress. Mirrors Schande:Impose's officer-whisper
 -- pattern.
 
-local KIND = SchlingelInc.Achievements.KIND
-
 SchlingelInc.Achievements.ManualGrant = {}
 local ManualGrant = SchlingelInc.Achievements.ManualGrant
 
@@ -23,7 +21,7 @@ function ManualGrant:Grant(targetName, achievementId)
     if not targetName or targetName == "" then return nil, "Kein Ziel gewählt." end
 
     local entry = SchlingelInc.Achievements.Catalog:Get(achievementId)
-    local grantable = entry and (entry.kind == KIND.MANUAL or entry.kind == KIND.LEVEL or entry.kind == KIND.KILL_COUNT)
+    local grantable = entry and SchlingelInc.Achievements.IsGrantableKind(entry.kind)
     if not entry or not grantable or entry.retired then
         return nil, "Ungültiger Erfolg."
     end
@@ -44,7 +42,7 @@ function ManualGrant:Revoke(targetName, achievementId)
     if not targetName or targetName == "" then return nil, "Kein Ziel gewählt." end
 
     local entry = SchlingelInc.Achievements.Catalog:Get(achievementId)
-    local grantable = entry and (entry.kind == KIND.MANUAL or entry.kind == KIND.LEVEL or entry.kind == KIND.KILL_COUNT)
+    local grantable = entry and SchlingelInc.Achievements.IsGrantableKind(entry.kind)
     if not entry or not grantable then
         return nil, "Ungültiger Erfolg."
     end

--- a/achievements/Progress.lua
+++ b/achievements/Progress.lua
@@ -6,16 +6,10 @@
 SchlingelInc.Achievements.Progress = {}
 local Progress = SchlingelInc.Achievements.Progress
 
-local KIND = SchlingelInc.Achievements.KIND
-
 local MSG_UNREACHED_REQUEST = "ACH_UNREACHED_REQUEST"
 local MSG_UNREACHED         = "ACH_UNREACHED"
 local MSG_REACHED_REQUEST   = "ACH_REACHED_REQUEST"
 local MSG_REACHED           = "ACH_REACHED"
-
-local function IsGlobalFlag(value)
-    return value == true or value == 1 or value == "1"
-end
 
 local function EnsureStores()
     SchlingelAchievementDB = SchlingelAchievementDB or {}
@@ -31,26 +25,19 @@ local function ResolveStores(id)
     EnsureStores()
 
     local entry = SchlingelInc.Achievements.Catalog:Get(id)
-    local useGlobal = entry and IsGlobalFlag(entry.isGlobal)
+    local useGlobal = entry and SchlingelInc.Achievements.IsTruthyFlag(entry.isGlobal)
 
     local unlockedStore = useGlobal and SchlingelAchievementDB.globalUnlocked or SchlingelOwnAchievements.unlocked
-    local killStore = useGlobal and SchlingelAchievementDB.globalKillProgress or SchlingelOwnAchievements.killProgress
+    local killStore     = useGlobal and SchlingelAchievementDB.globalKillProgress or SchlingelOwnAchievements.killProgress
+    local otherUnlocked  = useGlobal and SchlingelOwnAchievements.unlocked or SchlingelAchievementDB.globalUnlocked
+    local otherKill      = useGlobal and SchlingelOwnAchievements.killProgress or SchlingelAchievementDB.globalKillProgress
 
     -- Keep progress when officers toggle an achievement between character/global scope.
-    if useGlobal then
-        if unlockedStore[id] == nil and SchlingelOwnAchievements.unlocked[id] ~= nil then
-            unlockedStore[id] = SchlingelOwnAchievements.unlocked[id]
-        end
-        if killStore[id] == nil and SchlingelOwnAchievements.killProgress[id] ~= nil then
-            killStore[id] = SchlingelOwnAchievements.killProgress[id]
-        end
-    else
-        if unlockedStore[id] == nil and SchlingelAchievementDB.globalUnlocked[id] ~= nil then
-            unlockedStore[id] = SchlingelAchievementDB.globalUnlocked[id]
-        end
-        if killStore[id] == nil and SchlingelAchievementDB.globalKillProgress[id] ~= nil then
-            killStore[id] = SchlingelAchievementDB.globalKillProgress[id]
-        end
+    if unlockedStore[id] == nil and otherUnlocked[id] ~= nil then
+        unlockedStore[id] = otherUnlocked[id]
+    end
+    if killStore[id] == nil and otherKill[id] ~= nil then
+        killStore[id] = otherKill[id]
     end
 
     return unlockedStore, killStore
@@ -176,10 +163,6 @@ function Progress:Revoke(id)
 end
 
 -- Achievement kinds an officer can manually grant (mirrors ManualGrant's allow-list).
-local function IsGrantableKind(kind)
-    return kind == KIND.LEVEL or kind == KIND.MANUAL or kind == KIND.KILL_COUNT
-end
-
 -- Own not-yet-unlocked grantable achievement ids, for the achievement-grant popup.
 -- Sending the "still missing" set rather than the "already have" set keeps the
 -- response short for veteran characters, who are exactly the ones with the most
@@ -187,7 +170,7 @@ end
 local function OwnUnreachedGrantableIds()
     local ids = {}
     for _, entry in ipairs(SchlingelInc.Achievements.Catalog:GetActive()) do
-        if IsGrantableKind(entry.kind) and not Progress:IsUnlocked(entry.id) then
+        if SchlingelInc.Achievements.IsGrantableKind(entry.kind) and not Progress:IsUnlocked(entry.id) then
             table.insert(ids, entry.id)
         end
     end
@@ -199,7 +182,7 @@ end
 local function OwnReachedGrantableIds()
     local ids = {}
     for _, entry in ipairs(SchlingelInc.Achievements.Catalog:GetAll()) do
-        if IsGrantableKind(entry.kind) and Progress:IsUnlocked(entry.id) then
+        if SchlingelInc.Achievements.IsGrantableKind(entry.kind) and Progress:IsUnlocked(entry.id) then
             table.insert(ids, entry.id)
         end
     end

--- a/achievements/init.lua
+++ b/achievements/init.lua
@@ -16,6 +16,23 @@ SchlingelInc.Achievements.KIND = {
     MANUAL     = "manual",      -- no criteria; only unlockable via officer grant (RP achievements)
 }
 
+SchlingelInc.Achievements.KIND_LABELS = {
+    [SchlingelInc.Achievements.KIND.LEVEL]      = "Level",
+    [SchlingelInc.Achievements.KIND.KILL_COUNT] = "Kill-Zähler",
+    [SchlingelInc.Achievements.KIND.MANUAL]     = "Manuell (RP)",
+}
+
+-- Coerces a stored boolean-ish value (Lua true, or "1"/1 from wire/SavedVariables
+-- round-trips) to an actual boolean. Used for isGlobal, requireNoDeath, etc.
+function SchlingelInc.Achievements.IsTruthyFlag(value)
+    return value == true or value == 1 or value == "1"
+end
+
+function SchlingelInc.Achievements.IsGrantableKind(kind)
+    local KIND = SchlingelInc.Achievements.KIND
+    return kind == KIND.LEVEL or kind == KIND.MANUAL or kind == KIND.KILL_COUNT
+end
+
 SchlingelAchievementDB         = SchlingelAchievementDB         or {}
 SchlingelAchievementDB.entries = SchlingelAchievementDB.entries or {} -- [id] = definition
 SchlingelAchievementDB.globalUnlocked     = SchlingelAchievementDB.globalUnlocked     or {} -- [id] = timestamp

--- a/interfaces/GuildPanel/TabAchievements.lua
+++ b/interfaces/GuildPanel/TabAchievements.lua
@@ -22,7 +22,7 @@ end
 local function CriteriaHint(entry)
     if entry.kind == KIND.LEVEL then
         local threshold = tonumber(entry.critA) or 0
-        local requireNoDeath = entry.critB == true or entry.critB == 1 or entry.critB == "1"
+        local requireNoDeath = SchlingelInc.Achievements.IsTruthyFlag(entry.critB)
         return "Level " .. threshold .. (requireNoDeath and " (ohne zu sterben)" or "")
     elseif entry.kind == KIND.KILL_COUNT then
         return (tonumber(entry.critB) or 0) .. " Kills"
@@ -50,7 +50,7 @@ local function CreateCard(parent, cardW, entry)
     local safeId = entry.id
     local safeName = SchlingelInc:SanitizeText(entry.name) or "(ohne Namen)"
     local safePoints = tonumber(entry.points) or 0
-    local isGlobal = entry.isGlobal == true or entry.isGlobal == 1 or entry.isGlobal == "1"
+    local isGlobal = SchlingelInc.Achievements.IsTruthyFlag(entry.isGlobal)
 
     local card = CreateFrame("Frame", nil, parent, "BackdropTemplate")
     card:SetBackdrop({
@@ -117,13 +117,13 @@ local function CreateCard(parent, cardW, entry)
     return card
 end
 
-local RANK_BAR_H = 54
+local RANK_BAR_H = 76
 local REFRESH_COOLDOWN_SECONDS = 30
 
 function GP.BuildAchievementsTab(content)
     -- ── Rank + progress bar ──────────────────────────────────────────────────
     local rankFs = content:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    rankFs:SetPoint("TOPLEFT", content, "TOPLEFT", 4, -2)
+    rankFs:SetPoint("TOPLEFT", content, "TOPLEFT", 4, -24)
     rankFs:SetJustifyH("LEFT")
     rankFs:SetTextColor(1, 0.82, 0, 1)
 

--- a/interfaces/GuildPanel/TabAchievements.lua
+++ b/interfaces/GuildPanel/TabAchievements.lua
@@ -118,6 +118,7 @@ local function CreateCard(parent, cardW, entry)
 end
 
 local RANK_BAR_H = 54
+local REFRESH_COOLDOWN_SECONDS = 30
 
 function GP.BuildAchievementsTab(content)
     -- ── Rank + progress bar ──────────────────────────────────────────────────
@@ -125,6 +126,16 @@ function GP.BuildAchievementsTab(content)
     rankFs:SetPoint("TOPLEFT", content, "TOPLEFT", 4, -2)
     rankFs:SetJustifyH("LEFT")
     rankFs:SetTextColor(1, 0.82, 0, 1)
+
+    local refreshBtn = CreateFrame("Button", nil, content, "UIPanelButtonTemplate")
+    refreshBtn:SetSize(110, 20)
+    refreshBtn:SetPoint("TOPRIGHT", content, "TOPRIGHT", 0, -2)
+    refreshBtn:SetText("Aktualisieren")
+    refreshBtn:SetScript("OnClick", function()
+        SchlingelInc.Achievements.Catalog:RequestSync()
+        refreshBtn:Disable()
+        C_Timer.After(REFRESH_COOLDOWN_SECONDS, function() refreshBtn:Enable() end)
+    end)
 
     local rankBar = CreateFrame("StatusBar", nil, content, "BackdropTemplate")
     rankBar:SetPoint("TOPLEFT", rankFs, "BOTTOMLEFT", 0, -4)

--- a/interfaces/OfficerPanel/TabAchievements.lua
+++ b/interfaces/OfficerPanel/TabAchievements.lua
@@ -10,15 +10,10 @@ local CARD_GAP = 6
 local CARD_PAD = 8
 
 local KIND = SchlingelInc.Achievements.KIND
-
-local KIND_LABELS = {
-    [KIND.LEVEL]      = "Level",
-    [KIND.KILL_COUNT] = "Kill-Zähler",
-    [KIND.MANUAL]     = "Manuell (RP)",
-}
+local KIND_LABELS = SchlingelInc.Achievements.KIND_LABELS
 
 local function ScopeText(entry)
-    if entry.isGlobal == true or entry.isGlobal == 1 or entry.isGlobal == "1" then
+    if SchlingelInc.Achievements.IsTruthyFlag(entry.isGlobal) then
         return "Global"
     end
     return "Char"
@@ -27,7 +22,7 @@ end
 local function CriteriaText(entry)
     if entry.kind == KIND.LEVEL then
         local threshold = tonumber(entry.critA) or 0
-        local requireNoDeath = entry.critB == true or entry.critB == 1 or entry.critB == "1"
+        local requireNoDeath = SchlingelInc.Achievements.IsTruthyFlag(entry.critB)
         return "Level " .. threshold .. (requireNoDeath and " (ohne zu sterben)" or "")
     elseif entry.kind == KIND.KILL_COUNT then
         return "NPC-ID " .. (tostring(entry.critA) or "?") .. ", " .. (tostring(entry.critB) or "?") .. " Kills"

--- a/interfaces/popups/AchievementActionForm.lua
+++ b/interfaces/popups/AchievementActionForm.lua
@@ -1,0 +1,229 @@
+-- interfaces/popups/AchievementActionForm.lua
+-- Shared builder for the officer "grant"/"revoke" achievement popups: a small
+-- scrollable card list of eligible achievements for a target player, populated
+-- once their eligibility status arrives over the wire (see cfg.requestEligibility).
+
+SchlingelInc.Popup = SchlingelInc.Popup or {}
+
+local FORM_W  = 340
+local FORM_H  = 420
+local CARD_GAP = 6
+local CARD_PAD = 8
+local STATUS_TIMEOUT = 5
+
+local function CreateCard(parent, cardW, entry, onClick)
+    local card = CreateFrame("Button", nil, parent, "BackdropTemplate")
+    card:SetBackdrop({
+        bgFile   = "Interface\\BUTTONS\\WHITE8X8",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = true, tileSize = 16, edgeSize = 12,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 }
+    })
+    card:SetBackdropColor(0.12, 0.12, 0.12, 0.9)
+    card:SetBackdropBorderColor(0.4, 0.4, 0.4, 1)
+    card:SetWidth(cardW)
+    card:SetHeight(40)
+
+    local nameFs = card:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    nameFs:SetPoint("TOPLEFT", card, "TOPLEFT", CARD_PAD, -CARD_PAD)
+    nameFs:SetPoint("RIGHT", card, "RIGHT", -CARD_PAD, 0)
+    nameFs:SetJustifyH("LEFT")
+    nameFs:SetText(SchlingelInc:SanitizeText(entry.name) or "(ohne Namen)")
+    nameFs:SetTextColor(1, 1, 1, 1)
+
+    local metaFs = card:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    metaFs:SetPoint("TOPLEFT", nameFs, "BOTTOMLEFT", 0, -3)
+    metaFs:SetText((entry.points or 0) .. " Punkte — " .. (SchlingelInc.Achievements.KIND_LABELS[entry.kind] or entry.kind))
+    metaFs:SetTextColor(0.6, 0.8, 1, 1)
+
+    card:SetScript("OnEnter", function() card:SetBackdropBorderColor(1, 0.82, 0, 1) end)
+    card:SetScript("OnLeave", function() card:SetBackdropBorderColor(0.4, 0.4, 0.4, 1) end)
+    card:SetScript("OnClick", function() onClick(entry) end)
+
+    return card
+end
+
+local function BuildForm(frameName, positionKey)
+    local f = CreateFrame("Frame", frameName, UIParent, "BackdropTemplate")
+    f:SetSize(FORM_W, FORM_H)
+    f:SetFrameStrata("DIALOG")
+    f:SetBackdrop(SchlingelInc.Constants.BACKDROP)
+    f:SetBackdropColor(0.07, 0.07, 0.07, 0.98)
+    f:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
+    f:SetMovable(true)
+    f:EnableMouse(true)
+    f:RegisterForDrag("LeftButton")
+    f:SetScript("OnDragStart", f.StartMoving)
+    f:SetScript("OnDragStop", function(self)
+        self:StopMovingOrSizing()
+        SchlingelInc:SaveFramePosition(self, positionKey)
+    end)
+    SchlingelInc:RestoreFramePosition(f, positionKey, "CENTER", 0, 80)
+    SchlingelInc:RegisterFrameForEscape(f)
+    f:Hide()
+
+    local titleFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+    titleFs:SetPoint("TOP", f, "TOP", 0, -14)
+    titleFs:SetTextColor(1, 0.82, 0, 1)
+    f.titleFs = titleFs
+
+    local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
+    closeBtn:SetSize(20, 20)
+    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -2, -2)
+    closeBtn:SetScript("OnClick", function()
+        if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
+        f:Hide()
+    end)
+
+    local statusFs = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    statusFs:SetPoint("TOP", f, "TOP", 0, -32)
+    statusFs:SetPoint("LEFT", f, "LEFT", 10, 0)
+    statusFs:SetPoint("RIGHT", f, "RIGHT", -10, 0)
+    statusFs:SetJustifyH("CENTER")
+    f.statusFs = statusFs
+
+    local divider = f:CreateTexture(nil, "ARTWORK")
+    divider:SetHeight(1)
+    divider:SetColorTexture(0.4, 0.4, 0.4, 0.7)
+    divider:SetPoint("TOPLEFT",  f, "TOPLEFT",  10, -46)
+    divider:SetPoint("TOPRIGHT", f, "TOPRIGHT", -10, -46)
+
+    local scrollFrame = CreateFrame("ScrollFrame", nil, f, "UIPanelScrollFrameTemplate")
+    scrollFrame:SetPoint("TOPLEFT",     f, "TOPLEFT",     10, -52)
+    scrollFrame:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -30, 14)
+    scrollFrame:EnableMouseWheel(true)
+    scrollFrame:SetScript("OnMouseWheel", function(sf, delta)
+        sf:SetVerticalScroll(
+            math.max(0, math.min(sf:GetVerticalScrollRange(), sf:GetVerticalScroll() - delta * 24))
+        )
+    end)
+    f.scrollFrame = scrollFrame
+
+    local scrollChild = CreateFrame("Frame", nil, scrollFrame)
+    scrollChild:SetHeight(1)
+    scrollFrame:SetScrollChild(scrollChild)
+    f.scrollChild = scrollChild
+
+    f.cards = {}
+
+    return f
+end
+
+-- cfg = {
+--   popupKey          : string    -- SchlingelInc.Popup[popupKey] stores the built form frame
+--   frameName         : string
+--   positionKey       : string
+--   confirmDialogKey  : string    -- StaticPopupDialogs key, registered once here
+--   confirmText       : string    -- e.g. "Erfolg \"%s\" an %s verleihen?"
+--   confirmButton     : string
+--   titlePrefix       : string    -- e.g. "Erfolg verleihen: "
+--   getEntries        : function() -> array of achievement entries (Catalog:GetActive/:GetAll)
+--   eligibleSetField  : string    -- field on f holding the id->true set once it arrives
+--   isEligible        : function(f, entry) -> bool, using eligibleSetField
+--   emptyWithSet      : string    -- shown once the set arrived but nothing qualifies
+--   emptyNoSet        : string    -- shown while still waiting on the set
+--   requestEligibility: function(targetName)
+--   performAction     : function(targetName, id)
+-- }
+-- Returns { Show = function(targetName), OnReceived = function(senderShort, ids) }
+function SchlingelInc.Popup.CreateAchievementActionForm(cfg)
+    local currentTarget = nil
+
+    StaticPopupDialogs[cfg.confirmDialogKey] = {
+        text = cfg.confirmText,
+        button1 = cfg.confirmButton,
+        button2 = "Abbrechen",
+        OnAccept = function(self)
+            local data = self.data
+            cfg.performAction(data.target, data.id)
+            local f = SchlingelInc.Popup[cfg.popupKey]
+            if f then f:Hide() end
+        end,
+        timeout = 0,
+        whileDead = true,
+        hideOnEscape = true,
+        preferredIndex = 3,
+    }
+
+    local function Refresh(f)
+        for _, c in ipairs(f.cards) do c:Hide() end
+        wipe(f.cards)
+
+        local cardW = math.max(1, f.scrollFrame:GetWidth())
+        f.scrollChild:SetWidth(cardW)
+
+        local eligible = {}
+        for _, entry in ipairs(cfg.getEntries()) do
+            if SchlingelInc.Achievements.IsGrantableKind(entry.kind) and cfg.isEligible(f, entry) then
+                table.insert(eligible, entry)
+            end
+        end
+
+        local yOff = 0
+        if #eligible == 0 then
+            local msg = f.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+            msg:SetPoint("TOPLEFT", f.scrollChild, "TOPLEFT", 4, 0)
+            msg:SetText(f[cfg.eligibleSetField] and cfg.emptyWithSet or cfg.emptyNoSet)
+            msg:SetTextColor(0.6, 0.6, 0.6, 1)
+            table.insert(f.cards, msg)
+            yOff = -20
+        else
+            for _, entry in ipairs(eligible) do
+                local card = CreateCard(f.scrollChild, cardW, entry, function(selected)
+                    StaticPopup_Show(cfg.confirmDialogKey, selected.name, currentTarget,
+                        { target = currentTarget, id = selected.id })
+                end)
+                card:SetPoint("TOPLEFT", f.scrollChild, "TOPLEFT", 0, yOff)
+                table.insert(f.cards, card)
+                yOff = yOff - card:GetHeight() - CARD_GAP
+            end
+        end
+
+        f.scrollChild:SetHeight(math.max(1, -yOff))
+    end
+
+    local function Show(targetName)
+        if not targetName or targetName == "" then return end
+        if not SchlingelInc.Popup[cfg.popupKey] then
+            SchlingelInc.Popup[cfg.popupKey] = BuildForm(cfg.frameName, cfg.positionKey)
+        end
+        local f = SchlingelInc.Popup[cfg.popupKey]
+
+        if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
+
+        currentTarget = targetName
+        f[cfg.eligibleSetField] = nil
+        f.titleFs:SetText(cfg.titlePrefix .. targetName)
+        f.statusFs:SetTextColor(0.8, 0.8, 0.4, 1)
+        f.statusFs:SetText("Frage Freischaltungsstatus ab...")
+        Refresh(f)
+        SchlingelInc:RestoreFramePosition(f, cfg.positionKey, "CENTER", 0, 80)
+        f:Show()
+
+        cfg.requestEligibility(targetName)
+        f.timeoutTimer = C_Timer.NewTimer(STATUS_TIMEOUT, function()
+            f.timeoutTimer = nil
+            if currentTarget == targetName and not f[cfg.eligibleSetField] then
+                f.statusFs:SetTextColor(1, 0.4, 0.4, 1)
+                f.statusFs:SetText("Status konnte nicht bestätigt werden — bitte beim Spieler nachfragen.")
+            end
+        end)
+    end
+
+    -- Routes an incoming eligibility response to the popup if it's still open for
+    -- this sender; stale responses (form closed or reopened for someone else) are ignored.
+    local function OnReceived(senderShort, ids)
+        local f = SchlingelInc.Popup[cfg.popupKey]
+        if not f or not f:IsShown() or currentTarget ~= senderShort then return end
+
+        if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
+
+        local set = {}
+        for _, id in ipairs(ids) do set[id] = true end
+        f[cfg.eligibleSetField] = set
+        f.statusFs:SetText("")
+        Refresh(f)
+    end
+
+    return { Show = Show, OnReceived = OnReceived }
+end

--- a/interfaces/popups/AchievementForm.lua
+++ b/interfaces/popups/AchievementForm.lua
@@ -315,10 +315,10 @@ function SchlingelInc.Popup:ShowAchievementForm(existingEntry)
         f.pointsEB:SetText(tostring(existingEntry.points or 0))
         f.SelectKind(existingEntry.kind)
         f.kindBtn:Disable() -- kind can't change after creation (criteria fields are kind-specific)
-        f.globalCb:SetChecked(existingEntry.isGlobal == true or existingEntry.isGlobal == 1 or existingEntry.isGlobal == "1")
+        f.globalCb:SetChecked(SchlingelInc.Achievements.IsTruthyFlag(existingEntry.isGlobal))
         if existingEntry.kind == KIND.LEVEL then
             f.levelEB:SetText(tostring(tonumber(existingEntry.critA) or ""))
-            f.noDeathCb:SetChecked(existingEntry.critB == true or existingEntry.critB == 1 or existingEntry.critB == "1")
+            f.noDeathCb:SetChecked(SchlingelInc.Achievements.IsTruthyFlag(existingEntry.critB))
         elseif existingEntry.kind == KIND.KILL_COUNT then
             f.npcEB:SetText(tostring(tonumber(existingEntry.critA) or ""))
             f.countEB:SetText(tostring(tonumber(existingEntry.critB) or ""))

--- a/interfaces/popups/AchievementGrantForm.lua
+++ b/interfaces/popups/AchievementGrantForm.lua
@@ -6,218 +6,29 @@
 
 SchlingelInc.Popup = SchlingelInc.Popup or {}
 
-local KIND = SchlingelInc.Achievements.KIND
-
-local KIND_LABELS = {
-    [KIND.LEVEL]  = "Level",
-    [KIND.MANUAL] = "Manuell (RP)",
-    [KIND.KILL_COUNT] = "Kill-Count"
-}
-
-local FORM_W  = 340
-local FORM_H  = 420
-local CARD_GAP = 6
-local CARD_PAD = 8
-local STATUS_TIMEOUT = 5
-
-local currentGrantTarget = nil
-
-StaticPopupDialogs["SCHLINGEL_ACHIEVEMENT_GRANT_CONFIRM"] = {
-    text = "Erfolg \"%s\" an %s verleihen?",
-    button1 = "Verleihen",
-    button2 = "Abbrechen",
-    OnAccept = function(self)
-        local data = self.data
-        SchlingelInc.Achievements.ManualGrant:Grant(data.target, data.id)
-        if SchlingelInc.Popup.achievementGrantForm then
-            SchlingelInc.Popup.achievementGrantForm:Hide()
-        end
-    end,
-    timeout = 0,
-    whileDead = true,
-    hideOnEscape = true,
-    preferredIndex = 3,
-}
-
-local function CreateCard(parent, cardW, entry, onClick)
-    local card = CreateFrame("Button", nil, parent, "BackdropTemplate")
-    card:SetBackdrop({
-        bgFile   = "Interface\\BUTTONS\\WHITE8X8",
-        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-        tile = true, tileSize = 16, edgeSize = 12,
-        insets = { left = 3, right = 3, top = 3, bottom = 3 }
-    })
-    card:SetBackdropColor(0.12, 0.12, 0.12, 0.9)
-    card:SetBackdropBorderColor(0.4, 0.4, 0.4, 1)
-    card:SetWidth(cardW)
-    card:SetHeight(40)
-
-    local nameFs = card:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    nameFs:SetPoint("TOPLEFT", card, "TOPLEFT", CARD_PAD, -CARD_PAD)
-    nameFs:SetPoint("RIGHT", card, "RIGHT", -CARD_PAD, 0)
-    nameFs:SetJustifyH("LEFT")
-    nameFs:SetText(SchlingelInc:SanitizeText(entry.name) or "(ohne Namen)")
-    nameFs:SetTextColor(1, 1, 1, 1)
-
-    local metaFs = card:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    metaFs:SetPoint("TOPLEFT", nameFs, "BOTTOMLEFT", 0, -3)
-    metaFs:SetText((entry.points or 0) .. " Punkte — " .. (KIND_LABELS[entry.kind] or entry.kind))
-    metaFs:SetTextColor(0.6, 0.8, 1, 1)
-
-    card:SetScript("OnEnter", function() card:SetBackdropBorderColor(1, 0.82, 0, 1) end)
-    card:SetScript("OnLeave", function() card:SetBackdropBorderColor(0.4, 0.4, 0.4, 1) end)
-    card:SetScript("OnClick", function() onClick(entry) end)
-
-    return card
-end
-
-local function BuildForm(frameName)
-    local f = CreateFrame("Frame", frameName, UIParent, "BackdropTemplate")
-    f:SetSize(FORM_W, FORM_H)
-    f:SetFrameStrata("DIALOG")
-    f:SetBackdrop(SchlingelInc.Constants.BACKDROP)
-    f:SetBackdropColor(0.07, 0.07, 0.07, 0.98)
-    f:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
-    f:SetMovable(true)
-    f:EnableMouse(true)
-    f:RegisterForDrag("LeftButton")
-    f:SetScript("OnDragStart", f.StartMoving)
-    f:SetScript("OnDragStop", function(self)
-        self:StopMovingOrSizing()
-        SchlingelInc:SaveFramePosition(self, "achievementgrantform_position")
-    end)
-    SchlingelInc:RestoreFramePosition(f, "achievementgrantform_position", "CENTER", 0, 80)
-    SchlingelInc:RegisterFrameForEscape(f)
-    f:Hide()
-
-    local titleFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-    titleFs:SetPoint("TOP", f, "TOP", 0, -14)
-    titleFs:SetTextColor(1, 0.82, 0, 1)
-    f.titleFs = titleFs
-
-    local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
-    closeBtn:SetSize(20, 20)
-    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -2, -2)
-    closeBtn:SetScript("OnClick", function()
-        if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
-        f:Hide()
-    end)
-
-    local statusFs = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    statusFs:SetPoint("TOP", f, "TOP", 0, -32)
-    statusFs:SetPoint("LEFT", f, "LEFT", 10, 0)
-    statusFs:SetPoint("RIGHT", f, "RIGHT", -10, 0)
-    statusFs:SetJustifyH("CENTER")
-    f.statusFs = statusFs
-
-    local divider = f:CreateTexture(nil, "ARTWORK")
-    divider:SetHeight(1)
-    divider:SetColorTexture(0.4, 0.4, 0.4, 0.7)
-    divider:SetPoint("TOPLEFT",  f, "TOPLEFT",  10, -46)
-    divider:SetPoint("TOPRIGHT", f, "TOPRIGHT", -10, -46)
-
-    local scrollFrame = CreateFrame("ScrollFrame", nil, f, "UIPanelScrollFrameTemplate")
-    scrollFrame:SetPoint("TOPLEFT",     f, "TOPLEFT",     10, -52)
-    scrollFrame:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -30, 14)
-    scrollFrame:EnableMouseWheel(true)
-    scrollFrame:SetScript("OnMouseWheel", function(sf, delta)
-        sf:SetVerticalScroll(
-            math.max(0, math.min(sf:GetVerticalScrollRange(), sf:GetVerticalScroll() - delta * 24))
-        )
-    end)
-    f.scrollFrame = scrollFrame
-
-    local scrollChild = CreateFrame("Frame", nil, scrollFrame)
-    scrollChild:SetHeight(1)
-    scrollFrame:SetScrollChild(scrollChild)
-    f.scrollChild = scrollChild
-
-    f.cards = {}
-
-    return f
-end
-
-local function IsGrantableKind(kind)
-    return kind == KIND.MANUAL or kind == KIND.LEVEL or kind == KIND.KILL_COUNT
-end
-
-local function RefreshGrantForm(f)
-    for _, c in ipairs(f.cards) do c:Hide() end
-    wipe(f.cards)
-
-    local cardW = math.max(1, f.scrollFrame:GetWidth())
-    f.scrollChild:SetWidth(cardW)
-
-    local grantable = {}
-    for _, entry in ipairs(SchlingelInc.Achievements.Catalog:GetActive()) do
-        local stillReachable = not f.unreachedSet or f.unreachedSet[entry.id]
-        if IsGrantableKind(entry.kind) and stillReachable then
-            table.insert(grantable, entry)
-        end
-    end
-
-    local yOff = 0
-    if #grantable == 0 then
-        local msg = f.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-        msg:SetPoint("TOPLEFT", f.scrollChild, "TOPLEFT", 4, 0)
-        msg:SetText(f.unreachedSet and "Spieler hat bereits alle verleihbaren Erfolge." or "Keine verleihbaren Erfolge vorhanden.")
-        msg:SetTextColor(0.6, 0.6, 0.6, 1)
-        table.insert(f.cards, msg)
-        yOff = -20
-    else
-        for _, entry in ipairs(grantable) do
-            local card = CreateCard(f.scrollChild, cardW, entry, function(selected)
-                StaticPopup_Show("SCHLINGEL_ACHIEVEMENT_GRANT_CONFIRM", selected.name, currentGrantTarget,
-                    { target = currentGrantTarget, id = selected.id })
-            end)
-            card:SetPoint("TOPLEFT", f.scrollChild, "TOPLEFT", 0, yOff)
-            table.insert(f.cards, card)
-            yOff = yOff - card:GetHeight() - CARD_GAP
-        end
-    end
-
-    f.scrollChild:SetHeight(math.max(1, -yOff))
-end
+local actionForm = SchlingelInc.Popup.CreateAchievementActionForm({
+    popupKey          = "achievementGrantForm",
+    frameName         = "SchlingelAchievementGrantForm",
+    positionKey       = "achievementgrantform_position",
+    confirmDialogKey  = "SCHLINGEL_ACHIEVEMENT_GRANT_CONFIRM",
+    confirmText       = "Erfolg \"%s\" an %s verleihen?",
+    confirmButton     = "Verleihen",
+    titlePrefix       = "Erfolg verleihen: ",
+    getEntries        = function() return SchlingelInc.Achievements.Catalog:GetActive() end,
+    eligibleSetField  = "unreachedSet",
+    -- Show everything grantable while we're still waiting on the real "unreached"
+    -- set, then narrow down once it arrives.
+    isEligible        = function(f, entry) return not f.unreachedSet or f.unreachedSet[entry.id] end,
+    emptyWithSet      = "Spieler hat bereits alle verleihbaren Erfolge.",
+    emptyNoSet        = "Keine verleihbaren Erfolge vorhanden.",
+    requestEligibility = function(targetName) SchlingelInc.Achievements.Progress:RequestUnreached(targetName) end,
+    performAction     = function(targetName, id) SchlingelInc.Achievements.ManualGrant:Grant(targetName, id) end,
+})
 
 function SchlingelInc.Popup:ShowAchievementGrantForm(targetName)
-    if not targetName or targetName == "" then return end
-    if not SchlingelInc.Popup.achievementGrantForm then
-        SchlingelInc.Popup.achievementGrantForm = BuildForm("SchlingelAchievementGrantForm")
-    end
-    local f = SchlingelInc.Popup.achievementGrantForm
-
-    if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
-
-    currentGrantTarget = targetName
-    f.unreachedSet = nil
-    f.titleFs:SetText("Erfolg verleihen: " .. targetName)
-    f.statusFs:SetTextColor(0.8, 0.8, 0.4, 1)
-    f.statusFs:SetText("Frage Freischaltungsstatus ab...")
-    RefreshGrantForm(f)
-    SchlingelInc:RestoreFramePosition(f, "achievementgrantform_position", "CENTER", 0, 80)
-    f:Show()
-
-    SchlingelInc.Achievements.Progress:RequestUnreached(targetName)
-    f.timeoutTimer = C_Timer.NewTimer(STATUS_TIMEOUT, function()
-        f.timeoutTimer = nil
-        if currentGrantTarget == targetName and not f.unreachedSet then
-            f.statusFs:SetTextColor(1, 0.4, 0.4, 1)
-            f.statusFs:SetText("Status konnte nicht bestätigt werden — bitte beim Spieler nachfragen.")
-        end
-    end)
+    actionForm.Show(targetName)
 end
 
--- Routes an incoming ACH_UNREACHED response to the popup if it's still open for
--- this sender; stale responses (form closed or reopened for someone else) are ignored.
 function SchlingelInc.Popup:OnUnreachedReceived(senderShort, ids)
-    local f = SchlingelInc.Popup.achievementGrantForm
-    if not f or not f:IsShown() or currentGrantTarget ~= senderShort then return end
-
-    if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
-
-    local set = {}
-    for _, id in ipairs(ids) do set[id] = true end
-    f.unreachedSet = set
-    f.statusFs:SetText("")
-    RefreshGrantForm(f)
+    actionForm.OnReceived(senderShort, ids)
 end

--- a/interfaces/popups/AchievementRevokeForm.lua
+++ b/interfaces/popups/AchievementRevokeForm.lua
@@ -5,218 +5,29 @@
 
 SchlingelInc.Popup = SchlingelInc.Popup or {}
 
-local KIND = SchlingelInc.Achievements.KIND
-
-local KIND_LABELS = {
-    [KIND.LEVEL] = "Level",
-    [KIND.MANUAL] = "Manuell (RP)",
-    [KIND.KILL_COUNT] = "Kill-Count"
-}
-
-local FORM_W  = 340
-local FORM_H  = 420
-local CARD_GAP = 6
-local CARD_PAD = 8
-local STATUS_TIMEOUT = 5
-
-local currentRevokeTarget = nil
-
-StaticPopupDialogs["SCHLINGEL_ACHIEVEMENT_REVOKE_CONFIRM"] = {
-    text = "Erfolg \"%s\" von %s entfernen?",
-    button1 = "Entfernen",
-    button2 = "Abbrechen",
-    OnAccept = function(self)
-        local data = self.data
-        SchlingelInc.Achievements.ManualGrant:Revoke(data.target, data.id)
-        if SchlingelInc.Popup.achievementRevokeForm then
-            SchlingelInc.Popup.achievementRevokeForm:Hide()
-        end
-    end,
-    timeout = 0,
-    whileDead = true,
-    hideOnEscape = true,
-    preferredIndex = 3,
-}
-
-local function CreateCard(parent, cardW, entry, onClick)
-    local card = CreateFrame("Button", nil, parent, "BackdropTemplate")
-    card:SetBackdrop({
-        bgFile   = "Interface\\BUTTONS\\WHITE8X8",
-        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-        tile = true, tileSize = 16, edgeSize = 12,
-        insets = { left = 3, right = 3, top = 3, bottom = 3 }
-    })
-    card:SetBackdropColor(0.12, 0.12, 0.12, 0.9)
-    card:SetBackdropBorderColor(0.4, 0.4, 0.4, 1)
-    card:SetWidth(cardW)
-    card:SetHeight(40)
-
-    local nameFs = card:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    nameFs:SetPoint("TOPLEFT", card, "TOPLEFT", CARD_PAD, -CARD_PAD)
-    nameFs:SetPoint("RIGHT", card, "RIGHT", -CARD_PAD, 0)
-    nameFs:SetJustifyH("LEFT")
-    nameFs:SetText(SchlingelInc:SanitizeText(entry.name) or "(ohne Namen)")
-    nameFs:SetTextColor(1, 1, 1, 1)
-
-    local metaFs = card:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    metaFs:SetPoint("TOPLEFT", nameFs, "BOTTOMLEFT", 0, -3)
-    metaFs:SetText((entry.points or 0) .. " Punkte — " .. (KIND_LABELS[entry.kind] or entry.kind))
-    metaFs:SetTextColor(0.6, 0.8, 1, 1)
-
-    card:SetScript("OnEnter", function() card:SetBackdropBorderColor(1, 0.82, 0, 1) end)
-    card:SetScript("OnLeave", function() card:SetBackdropBorderColor(0.4, 0.4, 0.4, 1) end)
-    card:SetScript("OnClick", function() onClick(entry) end)
-
-    return card
-end
-
-local function BuildForm()
-    local f = CreateFrame("Frame", "SchlingelAchievementRevokeForm", UIParent, "BackdropTemplate")
-    f:SetSize(FORM_W, FORM_H)
-    f:SetFrameStrata("DIALOG")
-    f:SetBackdrop(SchlingelInc.Constants.BACKDROP)
-    f:SetBackdropColor(0.07, 0.07, 0.07, 0.98)
-    f:SetBackdropBorderColor(0.45, 0.45, 0.45, 1)
-    f:SetMovable(true)
-    f:EnableMouse(true)
-    f:RegisterForDrag("LeftButton")
-    f:SetScript("OnDragStart", f.StartMoving)
-    f:SetScript("OnDragStop", function(self)
-        self:StopMovingOrSizing()
-        SchlingelInc:SaveFramePosition(self, "achievementrevokeform_position")
-    end)
-    SchlingelInc:RestoreFramePosition(f, "achievementrevokeform_position", "CENTER", 0, 80)
-    SchlingelInc:RegisterFrameForEscape(f)
-    f:Hide()
-
-    local titleFs = f:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-    titleFs:SetPoint("TOP", f, "TOP", 0, -14)
-    titleFs:SetTextColor(1, 0.82, 0, 1)
-    f.titleFs = titleFs
-
-    local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
-    closeBtn:SetSize(20, 20)
-    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -2, -2)
-    closeBtn:SetScript("OnClick", function()
-        if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
-        f:Hide()
-    end)
-
-    local statusFs = f:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    statusFs:SetPoint("TOP", f, "TOP", 0, -32)
-    statusFs:SetPoint("LEFT", f, "LEFT", 10, 0)
-    statusFs:SetPoint("RIGHT", f, "RIGHT", -10, 0)
-    statusFs:SetJustifyH("CENTER")
-    f.statusFs = statusFs
-
-    local divider = f:CreateTexture(nil, "ARTWORK")
-    divider:SetHeight(1)
-    divider:SetColorTexture(0.4, 0.4, 0.4, 0.7)
-    divider:SetPoint("TOPLEFT",  f, "TOPLEFT",  10, -46)
-    divider:SetPoint("TOPRIGHT", f, "TOPRIGHT", -10, -46)
-
-    local scrollFrame = CreateFrame("ScrollFrame", nil, f, "UIPanelScrollFrameTemplate")
-    scrollFrame:SetPoint("TOPLEFT",     f, "TOPLEFT",     10, -52)
-    scrollFrame:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -30, 14)
-    scrollFrame:EnableMouseWheel(true)
-    scrollFrame:SetScript("OnMouseWheel", function(sf, delta)
-        sf:SetVerticalScroll(
-            math.max(0, math.min(sf:GetVerticalScrollRange(), sf:GetVerticalScroll() - delta * 24))
-        )
-    end)
-    f.scrollFrame = scrollFrame
-
-    local scrollChild = CreateFrame("Frame", nil, scrollFrame)
-    scrollChild:SetHeight(1)
-    scrollFrame:SetScrollChild(scrollChild)
-    f.scrollChild = scrollChild
-
-    f.cards = {}
-
-    return f
-end
-
-local function IsGrantableKind(kind)
-    return kind == KIND.MANUAL or kind == KIND.LEVEL or kind == KIND.KILL_COUNT
-end
-
-local function Refresh(f)
-    for _, c in ipairs(f.cards) do c:Hide() end
-    wipe(f.cards)
-
-    local cardW = math.max(1, f.scrollFrame:GetWidth())
-    f.scrollChild:SetWidth(cardW)
-
-    local revokable = {}
-    for _, entry in ipairs(SchlingelInc.Achievements.Catalog:GetAll()) do
-        local isUnlocked = f.reachedSet and f.reachedSet[entry.id]
-        if IsGrantableKind(entry.kind) and isUnlocked then
-            table.insert(revokable, entry)
-        end
-    end
-
-    local yOff = 0
-    if #revokable == 0 then
-        local msg = f.scrollChild:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-        msg:SetPoint("TOPLEFT", f.scrollChild, "TOPLEFT", 4, 0)
-        msg:SetText(f.reachedSet and "Spieler hat keine entziehbaren Erfolge." or "Keine entziehbaren Erfolge vorhanden.")
-        msg:SetTextColor(0.6, 0.6, 0.6, 1)
-        table.insert(f.cards, msg)
-        yOff = -20
-    else
-        for _, entry in ipairs(revokable) do
-            local card = CreateCard(f.scrollChild, cardW, entry, function(selected)
-                StaticPopup_Show("SCHLINGEL_ACHIEVEMENT_REVOKE_CONFIRM", selected.name, currentRevokeTarget,
-                    { target = currentRevokeTarget, id = selected.id })
-            end)
-            card:SetPoint("TOPLEFT", f.scrollChild, "TOPLEFT", 0, yOff)
-            table.insert(f.cards, card)
-            yOff = yOff - card:GetHeight() - CARD_GAP
-        end
-    end
-
-    f.scrollChild:SetHeight(math.max(1, -yOff))
-end
+local actionForm = SchlingelInc.Popup.CreateAchievementActionForm({
+    popupKey          = "achievementRevokeForm",
+    frameName         = "SchlingelAchievementRevokeForm",
+    positionKey       = "achievementrevokeform_position",
+    confirmDialogKey  = "SCHLINGEL_ACHIEVEMENT_REVOKE_CONFIRM",
+    confirmText       = "Erfolg \"%s\" von %s entfernen?",
+    confirmButton     = "Entfernen",
+    titlePrefix       = "Erfolg entziehen: ",
+    getEntries        = function() return SchlingelInc.Achievements.Catalog:GetAll() end,
+    eligibleSetField  = "reachedSet",
+    -- Show nothing until the real "reached" set arrives — can't assume someone
+    -- has unlocked something before confirmed.
+    isEligible        = function(f, entry) return f.reachedSet and f.reachedSet[entry.id] end,
+    emptyWithSet      = "Spieler hat keine entziehbaren Erfolge.",
+    emptyNoSet        = "Keine entziehbaren Erfolge vorhanden.",
+    requestEligibility = function(targetName) SchlingelInc.Achievements.Progress:RequestReached(targetName) end,
+    performAction     = function(targetName, id) SchlingelInc.Achievements.ManualGrant:Revoke(targetName, id) end,
+})
 
 function SchlingelInc.Popup:ShowAchievementRevokeForm(targetName)
-    if not targetName or targetName == "" then return end
-    if not SchlingelInc.Popup.achievementRevokeForm then
-        SchlingelInc.Popup.achievementRevokeForm = BuildForm()
-    end
-    local f = SchlingelInc.Popup.achievementRevokeForm
-
-    if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
-
-    currentRevokeTarget = targetName
-    f.reachedSet = nil
-    f.titleFs:SetText("Erfolg entziehen: " .. targetName)
-    f.statusFs:SetTextColor(0.8, 0.8, 0.4, 1)
-    f.statusFs:SetText("Frage Freischaltungsstatus ab...")
-    Refresh(f)
-    SchlingelInc:RestoreFramePosition(f, "achievementrevokeform_position", "CENTER", 0, 80)
-    f:Show()
-
-    SchlingelInc.Achievements.Progress:RequestReached(targetName)
-    f.timeoutTimer = C_Timer.NewTimer(STATUS_TIMEOUT, function()
-        f.timeoutTimer = nil
-        if currentRevokeTarget == targetName and not f.reachedSet then
-            f.statusFs:SetTextColor(1, 0.4, 0.4, 1)
-            f.statusFs:SetText("Status konnte nicht bestätigt werden — bitte beim Spieler nachfragen.")
-        end
-    end)
+    actionForm.Show(targetName)
 end
 
--- Routes an incoming ACH_REACHED response to the revoke popup if it's still open for
--- this sender; stale responses (form closed or reopened for someone else) are ignored.
 function SchlingelInc.Popup:OnReachedReceived(senderShort, ids)
-    local f = SchlingelInc.Popup.achievementRevokeForm
-    if not f or not f:IsShown() or currentRevokeTarget ~= senderShort then return end
-
-    if f.timeoutTimer then f.timeoutTimer:Cancel() f.timeoutTimer = nil end
-
-    local set = {}
-    for _, id in ipairs(ids) do set[id] = true end
-    f.reachedSet = set
-    f.statusFs:SetText("")
-    Refresh(f)
+    actionForm.OnReceived(senderShort, ids)
 end


### PR DESCRIPTION
Löst #160.

- PLAYER_ENTERING_WORLD-Auto-Sync entfernt, Katalog-Aktualisierung jetzt manuell per Button (Erfolge-Tab)
- Jittered Reply + Suppression statt Broadcast-Storm bei jedem Sync-Request
- Relay durch jeden Peer statt nur durch den ursprünglichen Ersteller
- updatedAt-Versionierung gegen stale Broadcasts
- Relay-Traffic direkt über CTL statt geteiltem Wrapper
- Tooltip.lua: ungesicherte Achievements-Abfrage abgesichert
- KillDetector/LevelDetector: unnötigen Sort auf dem Hot-Path entfernt
- AchievementGrantForm/RevokeForm zusammengeführt (~180 Zeilen Duplikat entfernt)
- Diverse doppelte Helper zentralisiert (IsGrantableKind, IsTruthyFlag, KIND_LABELS)

Getestet: Grant/Revoke-Flow live bestätigt. Sync-Relay-Mechanismus (Jitter/Suppression) braucht noch einen zweiten Client zum Testen.

Follow-up: #162